### PR TITLE
Allow compile_dll to work when source is in tempdir()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@
   neither `pull` nor `branch` are included in the formal parameters
   (@krlmlr, #509).
 
+* `compile_dll()` can now build packages located in R's `tempdir()`
+  directory (@richfitz, #531).
+
 # devtools 1.5
 
 Four new functions make it easier to add useful infrastructure to packages:

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -29,7 +29,9 @@ compile_dll <- function(pkg = ".", quiet = FALSE) {
 
   # Mock install the package to generate the DLL
   if (!quiet) message("Re-compiling ", pkg$package)
-  inst <- install_min(pkg, tempdir(), components = "libs",
+  install_dir <- tempfile("devtools_install_")
+  dir.create(install_dir)
+  inst <- install_min(pkg, install_dir, components = "libs",
     args = if (needs_clean(pkg)) "--preclean",
     quiet = quiet)
 


### PR DESCRIPTION
`compile_dll()` currently fails when package is being built in `tempdir()`

I'm not sure how common this use case is, but the fix is simple enough.  The reproducible example seems contrived but I have a workflow that is basically doing this.

To trigger: try to build a package that needs compilation in the directory given by `tempdir()`, even as a subdirectory.  As `devtools:::install_min` works in `tempdir()` too, the preclean causes the entire package to be removed.

Undesirable behaviour:

```r
path <- tempdir()
file.copy(system.file("tests/testthat/testDllRcpp", package="devtools"),
          path, recursive=TRUE)
pkg <- file.path(path, "testDllRcpp")
dir(pkg) # package ready to be built/etc.
# This line will cause an error:
devtools::load_all(pkg) # or devtools::document(), etc
# Loading testDllRcpp
# Re-compiling testDllRcpp
# '/Library/Frameworks/R.framework/Resources/bin/R' --vanilla CMD INSTALL  \
#   '/private/var/folders/dm/6q6zdvzj0154h96p80vl15lc0000gn/T/RtmptdiZ58/testDllRcpp'  \
#   --library='/var/folders/dm/6q6zdvzj0154h96p80vl15lc0000gn/T//RtmptdiZ58'  \
#   --no-R --no-data --no-help --no-demo --no-inst --no-docs --no-exec  \
#   --no-multiarch --no-test-load --preclean 
#
# ERROR: cannot install to srcdir for package ‘testDllRcpp’
# * removing ‘/private/var/folders/dm/6q6zdvzj0154h96p80vl15lc0000gn/T/RtmptdiZ58/testDllRcpp’
# Error: Command failed (1)
```

The directory is now empty:

```
dir(pkg)
# character(0)
```

I didn't dig down into exactly how this is happening, but the clean seems to be the culprit.

Changing the line

```r
install_min(pkg, tempdir(), components = "libs",
```

to point at a subdirectory of `tempdir()` (created by `tempfile()`) makes the problem go away, isolating the build from the rest of the temporary directory.
