### PR TITLE
CRAN now requires `Title` field to be title case

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -214,7 +214,7 @@ build_description <- function(name, extra = list()) {
 
   defaults <- compact(list(
     Package = name,
-    Title = "What the package does (one line)",
+    Title = "What The Package Does (one line, title case)",
     Version = "0.1",
     "Authors@R" = getOption("devtools.desc.author"),
     Description = "What the package does (one paragraph)",


### PR DESCRIPTION
Updated defaults in build_description to reflect this. This is a new requirement; see https://github.com/wch/r-source/commit/1f0dcb55368d7509c8123ce0bff5c6ef95a48607