### PR TITLE
add NO_AUTO_CLEAN to needs_clean

### DIFF
--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -108,12 +108,33 @@ needs_compile <- function(pkg = ".") {
   source > dll
 }
 
+makevars <- function(pkg = ".") {
+  pkg <- as.package(pkg)
+  srcdir <- file.path(pkg$path, "src")
+  dir(srcdir, "^Makevars.*$", recursive = TRUE, full.names = TRUE)
+}
+
 # Does the package need a clean compile?
 # (i.e. is there a header or Makevars newer than the dll)
+# If the file Makevars includes a commented line like `# DEVTOOLS_NO_AUTO_CLEAN`,
+# then return FALSE and trust the Makevars to handle dependencies of
+# header files.
 needs_clean <- function(pkg = ".") {
   pkg <- as.package(pkg)
 
-  headers <- mtime(headers(pkg))
+  makevars <- makevars(pkg)
+  no_auto_clean <- FALSE
+  for (f in makevars) {
+    if (length(grep("^#+\\s*DEVTOOLS_NO_AUTO_CLEAN\\s*$", readLines(f, warn = FALSE))))
+    no_auto_clean <- TRUE
+  }
+
+  if (no_auto_clean) {
+    # Still check a Makevars newer than the dll
+    headers <- mtime(makevars)
+  } else {
+    headers <- mtime(headers(pkg))
+  }
   # no headers, so never needs clean compile
   if (is.null(headers)) return(FALSE)
 

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -130,7 +130,7 @@ needs_clean <- function(pkg = ".") {
   }
 
   if (no_auto_clean) {
-    # Still check a Makevars newer than the dll
+    # Run clean compiling when `Makevars` file is modified
     headers <- mtime(makevars)
   } else {
     headers <- mtime(headers(pkg))


### PR DESCRIPTION
Since the default Makefile in R doesn't handle dependencies of header
files, devtools run a clean compiling when a header or Makevars is newer
than the dll.

Based on (http://bruno.defraine.net/techtips/makefile-auto-dependencies-with-gcc/),
I use the following Makevars to handle dependencies in development
environment. It may improve compiling speed significantly when a header
file is modified.

``` make
# DEVTOOLS_NO_AUTO_CLEAN
PKG_CXXFLAGS=-MMD -MP

all: $(SHLIB)

SRC=$(wildcard *.cpp)
DEP=$(SRC:.cpp=.d)
-include $(DEP)
```

To work with the above or similar Makevars, we need a method to suppress
the auto cleaning mechanism of devtools. With this commit, needs_clean
will not trigger cleaning and let the Makevars handle dependencies of
header files, when it see a commented line `# DEVTOOLS_NO_AUTO_CLEAN` in
Makevars.
