### PR TITLE
Documentation of load_data() to .RData, not .Rdata

### DIFF
--- a/R/load-data.r
+++ b/R/load-data.r
@@ -1,6 +1,6 @@
 #' Load data.
 #'
-#' Loads all \code{.Rdata} files in the data subdirectory.
+#' Loads all \code{.RData} files in the data subdirectory.
 #'
 #' @param pkg package description, can be path or package name.  See
 #'   \code{\link{as.package}} for more information

--- a/man/load_data.Rd
+++ b/man/load_data.Rd
@@ -10,7 +10,7 @@ load_data(pkg = ".")
 \code{\link{as.package}} for more information}
 }
 \description{
-Loads all \code{.Rdata} files in the data subdirectory.
+Loads all \code{.RData} files in the data subdirectory.
 }
 \keyword{programming}
 


### PR DESCRIPTION
According to the R-extension manual data-files should have the extension
.RData and not .Rdata
(http://cran.r-project.org/doc/manuals/R-exts.html#Data-in-packages).
Consistent with that, load_data() only loads .RData files (at least on
windows), but no .Rdata files. I only changed the documentation to be
consistent with that, i.e., specifically refer to .RData files.