### PR TITLE
`release()` now builds packages without the `--no-manual` switch, both for checking and for actually building the release package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,13 @@
   
   * Checking that the version number has exactly three components (#633).
 
+* `release()` now builds packages without the `--no-manual` switch, both for
+  checking and for actually building the release package (#603, @krlmlr).
+
+  * `build()` gains an additional argument `manual`, defaults to `FALSE`.
+
+  * `check()` gains an ellipsis `...` which is passed unmodified to `build()`.
+
 * Removed deprecated `doc_clean` argument to `check()`.
 
 * Initial package version in `create()` is now `0.0.0.9000` (#632).

--- a/R/build.r
+++ b/R/build.r
@@ -15,8 +15,8 @@
 #'   the parent directory of the package.
 #' @param binary Produce a binary (\code{--binary}) or source (
 #'   \code{--no-manual --no-resave-data}) version of the package.
-#' @param vignettes For source packages: if \code{FALSE}, don't build PDF
-#'   vignettes (\code{--no-vignettes}).
+#' @param vignettes,manual For source packages: if \code{FALSE}, don't build PDF
+#'   vignettes (\code{--no-vignettes}) or manual (\code{--no-manual}).
 #' @param args An optional character vector of additional command
 #'   line arguments to be passed to \code{R CMD build} if \code{binary = FALSE},
 #'   or \code{R CMD install} if \code{binary = TRUE}.
@@ -26,7 +26,7 @@
 #' @return a string giving the location (including file name) of the built
 #'  package
 build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
-                  args = NULL, quiet = FALSE) {
+                  manual = FALSE, args = NULL, quiet = FALSE) {
   pkg <- as.package(pkg)
   check_build_tools(pkg)
 
@@ -42,7 +42,11 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
       paste0(args, collapse = " "))
     ext <- if (.Platform$OS.type == "windows") "zip" else "tgz"
   } else {
-    args <- c(args, "--no-manual", "--no-resave-data")
+    args <- c(args, "--no-resave-data")
+
+    if (!manual) {
+      args <- c(args, "--no-manual")
+    }
 
     if (!vignettes) {
       args <- c(args, "--no-build-vignettes")

--- a/R/check.r
+++ b/R/check.r
@@ -54,12 +54,14 @@
 #'   line arguments to be passed to \code{R CMD check}/\code{R CMD build}/\code{R CMD INSTALL}.
 #' @param quiet if \code{TRUE} suppresses output from this function.
 #' @param check_dir the directory in which the package is checked
+#' @param ... Additional arguments passed to \code{\link{build}}
 #' @seealso \code{\link{release}} if you want to send the checked package to
 #'   CRAN.
 #' @export
 check <- function(pkg = ".", document = TRUE, cleanup = TRUE, cran = TRUE,
                   check_version = FALSE, force_suggests = TRUE, args = NULL,
-                  build_args = NULL, quiet = FALSE, check_dir = tempdir()) {
+                  build_args = NULL, quiet = FALSE, check_dir = tempdir(),
+                  ...) {
 
   pkg <- as.package(pkg)
 
@@ -70,7 +72,7 @@ check <- function(pkg = ".", document = TRUE, cleanup = TRUE, cran = TRUE,
   old <- set_envvar(compiler_flags(FALSE), "prefix")
   on.exit(set_envvar(old))
 
-  built_path <- build(pkg, tempdir(), quiet = quiet, args = build_args)
+  built_path <- build(pkg, tempdir(), quiet = quiet, args = build_args, ...)
   on.exit(unlink(built_path), add = TRUE)
 
   r_cmd_check_path <- check_r_cmd(built_path, cran, check_version,

--- a/R/release.r
+++ b/R/release.r
@@ -46,7 +46,7 @@ release <- function(pkg = ".", check = TRUE) {
   new_pkg <- is.null(cran_version)
 
   if (check) {
-    check(pkg, cran = TRUE, check_version = TRUE)
+    check(pkg, cran = TRUE, check_version = TRUE, manual = TRUE)
     release_checks(pkg)
 
     if (yesno("Was package check successful?"))
@@ -251,7 +251,7 @@ submit_cran <- function(pkg = ".") {
   comments <- cran_comments(pkg)
 
   message("Building")
-  built_path <- build(pkg, tempdir())
+  built_path <- build(pkg, tempdir(), manual = TRUE)
   message("File size: ", file.info(built_path)$size, " bytes")
 
   # Initial upload ---------

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -4,7 +4,7 @@
 \title{Build package.}
 \usage{
 build(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
-  args = NULL, quiet = FALSE)
+  manual = FALSE, args = NULL, quiet = FALSE)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -16,8 +16,8 @@ the parent directory of the package.}
 \item{binary}{Produce a binary (\code{--binary}) or source (
 \code{--no-manual --no-resave-data}) version of the package.}
 
-\item{vignettes}{For source packages: if \code{FALSE}, don't build PDF
-vignettes (\code{--no-vignettes}).}
+\item{vignettes,manual}{For source packages: if \code{FALSE}, don't build PDF
+vignettes (\code{--no-vignettes}) or manual (\code{--no-manual}).}
 
 \item{args}{An optional character vector of additional command
 line arguments to be passed to \code{R CMD build} if \code{binary = FALSE},

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -5,7 +5,7 @@
 \usage{
 check(pkg = ".", document = TRUE, cleanup = TRUE, cran = TRUE,
   check_version = FALSE, force_suggests = TRUE, args = NULL,
-  build_args = NULL, quiet = FALSE, check_dir = tempdir())
+  build_args = NULL, quiet = FALSE, check_dir = tempdir(), ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -35,6 +35,8 @@ line arguments to be passed to \code{R CMD check}/\code{R CMD build}/\code{R CMD
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
 
 \item{check_dir}{the directory in which the package is checked}
+
+\item{...}{Additional arguments passed to \code{\link{build}}}
 }
 \description{
 \code{check} automatically builds and checks a source package, using all


### PR DESCRIPTION
* `build()` gains an additional argument `manual`, defaults to `FALSE`.
* `check()` gains an ellipsis `...` which is passed unmodified to `build()`.

Completely untested, submitted for review. Will report once it's tested.

Fixes #603.