### PR TITLE
Use correct repository when using install_github with a pull request

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,10 @@
 * `use_readme_rmd()` makes it easier to generate a `README.md` from 
   `README.Rmd`.
 
+* When installing a pull request, `install_github` now uses the repository
+  associated with the pull request's branch (and not the repository of the user
+  who created the pull request) (#658, @krlmlr).
+
 # devtools 1.6.1
 
 * Don't set non-portable compiler flags on Solaris.

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -168,7 +168,7 @@ github_resolve_ref.github_pull <- function(x, params) {
   path <- file.path("repos", params$username, params$repo, "pulls", x)
   response <- github_GET(path)
 
-  params$username <- response$user$login
+  params$username <- response$head$user$login
   params$ref <- response$head$ref
   params
 }

--- a/tests/testthat/test-github.r
+++ b/tests/testthat/test-github.r
@@ -53,7 +53,7 @@ test_that("GitHub parameters are returned correctly", {
 
 mock_github_GET <- function(path) {
   if (grepl("^repos/.*/pulls/.*$", path)) {
-    list(user=list(login="username"), head=list(ref="some-pull-request"))
+    list(head=list(user=list(login="username"), ref="some-pull-request"))
   } else if (grepl("^repos/.*/releases$", path)) {
     list(list(tag_name="some-release"))
   } else
@@ -65,6 +65,7 @@ test_that("GitHub references are resolved correctly", {
   with_mock("github_GET", mock_github_GET, {
     expect_equal(github_resolve_ref(NULL, list())$ref, "master")
     expect_equal(github_resolve_ref("some-ref", list())$ref, "some-ref")
+    expect_equal(github_resolve_ref(github_pull(123), default_params)$username, "username")
     expect_equal(github_resolve_ref(github_pull(123), default_params)$ref, "some-pull-request")
     expect_equal(github_resolve_ref(github_release(), default_params)$ref, "some-release")
   })


### PR DESCRIPTION
Installing a pull request now uses the repository associated with the pull request's branch (and not the repository of the user who created the pull request).

Example: A shared repository where a collaborator has issued a pull request within this shared repo, e.g., `devtools::install_github("johnmyleswhite/ProjectTemplate#134")`

Includes a test.