### PR TITLE
getPackageName -> methods::getPackageName

### DIFF
--- a/R/load-dll.r
+++ b/R/load-dll.r
@@ -81,7 +81,7 @@ addNamespaceDynLibs <- function(ns, newlibs) {
 # This is taken directly from base::loadNamespace in R 2.15.1
 # The only change is the line used get the package name
 assignNativeRoutines <- function(dll, lib, env, nativeRoutines) {
-  package <- getPackageName(env)
+  package <- methods::getPackageName(env)
 
   if(length(nativeRoutines) == 0L)
     return(NULL)

--- a/R/remove-s4-class.r
+++ b/R/remove-s4-class.r
@@ -5,7 +5,7 @@
 remove_s4_classes <- function(pkg = ".") {
   pkg <- as.package(pkg)
 
-  classes <- getClasses(ns_env(pkg))
+  classes <- methods::getClasses(ns_env(pkg))
   lapply(classes, remove_s4_class, pkg)
 }
 


### PR DESCRIPTION
`devtools:::assignNativeRoutines()` "assumed" the 'methods' is attached.  Fix is obvious.  Discovered it by the from running the following(*):
```r
res <- devtools::load_all(".", export_all=FALSE, quiet=FALSE, recompile=TRUE)
...
Error in assignNativeRoutines(dlls[[lib]], lib, env, nsInfo$nativeRoutines[[lib]
]) :
  could not find function "getPackageName"
```

Footnote:
(*) Actually from running `covr::package_coverage()`, but the above is basically the first thing it does.