### PR TITLE
Add default cache argument for lint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ Suggests:
     MASS,
     rmarkdown,
     knitr,
-    lintr
+    lintr (>= 0.2.1)
 License: GPL (>= 2)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.7.1.9000
 
+* `lint()` gains a `cache` argument (@jimhester, #708).
+
 * export functions `RCMD()` and `system_check()` so they can be used by other 
   packages. (@jimhester, #699).
 

--- a/R/lint.r
+++ b/R/lint.r
@@ -9,6 +9,10 @@
 #' use the previous results.
 #' @param ... additional arguments passed to \code{\link[lintr]{lint_package}}
 #' @seealso \code{\link[lintr]{lint_package}}, \code{\link[lintr]{lint}}
+#' @details
+#' The lintr cache is by default stored in \code{~/.R/lintr_cache/} (this can
+#' be configured by setting \code{options(lintr.cache_directory)}).  It can be
+#' cleared by calling \code{\link[lintr]{clear_cache}}.
 #' @export
 lint <- function(pkg = ".", cache = TRUE, ...) {
   check_lintr()

--- a/R/lint.r
+++ b/R/lint.r
@@ -15,7 +15,7 @@ lint <- function(pkg = ".", cache = TRUE, ...) {
   pkg <- as.package(pkg)
 
   message("Linting ", pkg$package, appendLF = FALSE)
-  lintr::lint_package(pkg$path, cache = TRUE, ...)
+  lintr::lint_package(pkg$path, cache = cache, ...)
 }
 
 check_lintr <- function() {

--- a/R/lint.r
+++ b/R/lint.r
@@ -5,15 +5,17 @@
 #' override any or all of them using the \code{linters} parameter.
 #' @param pkg package description, can be path or package name. See
 #'   \code{\link{as.package}} for more information
+#' @param cache store the lint results so repeated lints of the same content
+#' use the previous results.
 #' @param ... additional arguments passed to \code{\link[lintr]{lint_package}}
 #' @seealso \code{\link[lintr]{lint_package}}, \code{\link[lintr]{lint}}
 #' @export
-lint <- function(pkg = ".", ...) {
+lint <- function(pkg = ".", cache = TRUE, ...) {
   check_lintr()
   pkg <- as.package(pkg)
 
   message("Linting ", pkg$package, appendLF = FALSE)
-  lintr::lint_package(pkg$path, ...)
+  lintr::lint_package(pkg$path, cache = TRUE, ...)
 }
 
 check_lintr <- function() {

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -4,11 +4,14 @@
 \alias{lint}
 \title{Lint all source files in a package.}
 \usage{
-lint(pkg = ".", ...)
+lint(pkg = ".", cache = TRUE, ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name. See
 \code{\link{as.package}} for more information}
+
+\item{cache}{store the lint results so repeated lints of the same content
+use the previous results.}
 
 \item{...}{additional arguments passed to \code{\link[lintr]{lint_package}}}
 }

--- a/man/lint.Rd
+++ b/man/lint.Rd
@@ -20,6 +20,11 @@ The default lintings correspond to the style guide at
 \url{http://r-pkgs.had.co.nz/r.html#style}, however it is possible to
 override any or all of them using the \code{linters} parameter.
 }
+\details{
+The lintr cache is by default stored in \code{~/.R/lintr_cache/} (this can
+be configured by setting \code{options(lintr.cache_directory)}).  It can be
+cleared by calling \code{\link[lintr]{clear_cache}}.
+}
 \seealso{
 \code{\link[lintr]{lint_package}}, \code{\link[lintr]{lint}}
 }


### PR DESCRIPTION
Combined with the bugfix in 2fbfee237c39c47cda15e93e96ef74a16b4bc40d this allows use of the caching functionality in lintr.

Reference timings (lints were previously cached)
```r
system.time(devtools::lint('../../../devtools', cache = FALSE))
#> Linting devtools.....................................................................................................................................
#>    user  system elapsed
#>  85.842   0.660  86.692

system.time(devtools::lint('../../../devtools', cache = TRUE))
#> Linting devtools.....................................................................................................................................
#>    user  system elapsed
#>   3.990   0.139   4.187