### PR TITLE
Allow to override NOT_CRAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 * `dev_help()` now uses `normalizePath()`. Hopefully this will make it more
   likely to work if you're on windows and have a space in the path.
 
+* `NOT_CRAN` is no longer set automatically if it has been set externally to
+  allow overriding.
+
 # devtools 1.7.0
 
 ## Improve reverse dependency checking

--- a/R/R.r
+++ b/R/R.r
@@ -51,8 +51,7 @@ r_env_vars <- function() {
 
   if(is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
     c(vars, "NOT_CRAN" = "true")
-  }
-  else {
+  } else {
     vars
   }
 }

--- a/R/R.r
+++ b/R/R.r
@@ -33,21 +33,24 @@ RCMD <- function(cmd, options, path = tempdir(), env_vars = NULL, ...) {
 #' between the current R session and the new session, and to ensure that
 #' everything behaves the same across systems. It also suppresses a common
 #' warning on windows, and sets \code{NOT_CRAN} so you can tell that your
-#' code is not running on CRAN.
+#' code is not running on CRAN. If \code{NOT_CRAN} has been set externally, it
+#' is not overwritten.
 #'
 #' @keywords internal
 #' @return a named character vector
 #' @export
 r_env_vars <- function() {
-  c("R_LIBS" = paste(.libPaths(), collapse = .Platform$path.sep),
+  vars <- c("R_LIBS" = paste(.libPaths(), collapse = .Platform$path.sep),
     "CYGWIN" = "nodosfilewarning",
     # When R CMD check runs tests, it sets R_TESTS. When the tests
     # themselves run R CMD xxxx, as is the case with the tests in
     # devtools, having R_TESTS set causes errors because it confuses
     # the R subprocesses. Un-setting it here avoids those problems.
     "R_TESTS" = "",
-    "NOT_CRAN" = "true",
     "TAR" = auto_tar())
+
+  if(is.na(Sys.getenv("NOT_CRAN", unset = NA))) c(vars, "NOT_CRAN" = "true")
+  else vars
 }
 
 # Determine the best setting for the TAR environmental variable

--- a/R/R.r
+++ b/R/R.r
@@ -49,7 +49,9 @@ r_env_vars <- function() {
     "R_TESTS" = "",
     "TAR" = auto_tar())
 
-  if(is.na(Sys.getenv("NOT_CRAN", unset = NA))) c(vars, "NOT_CRAN" = "true")
+  if(is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
+    c(vars, "NOT_CRAN" = "true")
+  }
   else vars
 }
 

--- a/R/R.r
+++ b/R/R.r
@@ -52,7 +52,9 @@ r_env_vars <- function() {
   if(is.na(Sys.getenv("NOT_CRAN", unset = NA))) {
     c(vars, "NOT_CRAN" = "true")
   }
-  else vars
+  else {
+    vars
+  }
 }
 
 # Determine the best setting for the TAR environmental variable

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -21,25 +21,24 @@ archived source tarballs and tries to install an older version instead.}
     \code{"http://cran.us.r-project.org"}.  For more details on
     supported URL schemes see \code{\link{url}}.
 
-    Can be \code{NULL} to install from local files, directories or URLs:
-    this will be inferred by extension from \code{pkgs} if of length one.
+    Can be \code{NULL} to install from local files
+    (with extension \file{.tar.gz} for source packages).
   }
 
 \item{type}{character, indicating the type of package to download and
     install.
 
-    Possible values are (currently) \code{"source"},
-    \code{"mac.binary"}, \code{"mac.binary.mavericks"} and
-    \code{"win.binary"}: the binary types can be listed and downloaded
-    but not installed on other platforms.
+    Possible values are (currently) \code{"source"}, \code{"mac.binary"}
+    and \code{"win.binary"}: the binary types can be listed and
+    downloaded but not installed on other platforms.
 
     The default is the appropriate binary type on Windows and on the
-    CRAN binary OS X distributions, otherwise \code{"source"}.  For the
-    platforms where binary packages are the default, an alternative is
-    \code{"both"} which means \sQuote{try binary if available and
-    current, otherwise try source}.  (This will only choose the binary
-    package if its version number is no older than the source version.
-    In interactive use it will ask before attempting to install source
+    CRAN binary OS X distribution, otherwise \code{"source"}.  For
+    the platforms where binary packages are the default, an alternative
+    is \code{"both"} which means \sQuote{try binary if available,
+    otherwise try source}.  (This will only choose the binary package if
+    its version number is no older than the source version.  In
+    interactive use it will ask before attempting to install source
     packages.)
   }
 

--- a/man/r_env_vars.Rd
+++ b/man/r_env_vars.Rd
@@ -14,7 +14,8 @@ Devtools sets a number of environmental variables to ensure consistent
 between the current R session and the new session, and to ensure that
 everything behaves the same across systems. It also suppresses a common
 warning on windows, and sets \code{NOT_CRAN} so you can tell that your
-code is not running on CRAN.
+code is not running on CRAN. If \code{NOT_CRAN} has been set externally, it
+is not overwritten.
 }
 \keyword{internal}
 


### PR DESCRIPTION
Currently devtools always sets `NOT_CRAN`. In some cases, it's desirable to override this behaviour (e.g. to check the behaviour on CRAN). This patch simply checks whether `NOT_CRAN` has been set externally and if so, doesn't change it.