### PR TITLE
Add argument to `install()` and `install_deps()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.7.1.9000
 
+* `install()` and `install_deps()` gain a `...` argument, so additional
+  arguments can be passed to `utils::install.packages()` (@jimhester, #712).
+
 * `lint()` gains a `cache` argument (@jimhester, #708).
 
 * export functions `RCMD()` and `system_check()` so they can be used by other 

--- a/R/install.r
+++ b/R/install.r
@@ -43,6 +43,7 @@
 #' @param threads number of concurrent threads to use for installing
 #'   dependencies.
 #'   It defaults to the option \code{"Ncpus"} or \code{1} if unset.
+#' @param ... additional arguments passed to \code{\link{install.packages}}
 #' @export
 #' @family package installation
 #' @seealso \code{\link{with_debug}} to install packages with debugging flags
@@ -51,7 +52,8 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
                     args = getOption("devtools.install.args"), quiet = FALSE,
                     dependencies = NA, build_vignettes = FALSE,
                     keep_source = getOption("keep.source.pkgs"),
-                    threads = getOption("Ncpus", 1)) {
+                    threads = getOption("Ncpus", 1),
+                    ...) {
 
   pkg <- as.package(pkg)
   check_build_tools(pkg)
@@ -62,7 +64,7 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   if (build_vignettes && missing(dependencies)) {
     dependencies <- TRUE
   }
-  install_deps(pkg, dependencies = dependencies, threads = threads)
+  install_deps(pkg, dependencies = dependencies, threads = threads, ...)
 
   # Build the package. Only build locally if it doesn't have vignettes
   has_vignettes <- length(tools::pkgVignettes(dir = pkg$path)$docs > 0)
@@ -98,7 +100,8 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
 #' @examples
 #' \dontrun{install_deps(".")}
 install_deps <- function(pkg = ".", dependencies = NA,
-                         threads = getOption("Ncpus", 1)) {
+                         threads = getOption("Ncpus", 1),
+                         ...) {
   pkg <- as.package(pkg)
   info <- pkg_deps(pkg, dependencies)
 
@@ -116,7 +119,7 @@ install_deps <- function(pkg = ".", dependencies = NA,
 
   message("Installing dependencies for ", pkg$package, ":\n",
     paste(deps, collapse = ", "))
-  utils::install.packages(deps, dependencies = NA, Ncpus = threads)
+  utils::install.packages(deps, dependencies = NA, Ncpus = threads, ...)
   invisible(deps)
 }
 

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -8,7 +8,7 @@ install(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   args = getOption("devtools.install.args"), quiet = FALSE,
   dependencies = NA, build_vignettes = FALSE,
   keep_source = getOption("keep.source.pkgs"), threads = getOption("Ncpus",
-  1))
+  1), ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -48,6 +48,8 @@ It defaults to the option \code{"keep.source.pkgs"}.}
 \item{threads}{number of concurrent threads to use for installing
 dependencies.
 It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
+
+\item{...}{additional arguments passed to \code{\link{install.packages}}}
 }
 \description{
 Uses \code{R CMD INSTALL} to install the package. Will also try to install

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -5,7 +5,7 @@
 \title{Install package dependencies}
 \usage{
 install_deps(pkg = ".", dependencies = NA, threads = getOption("Ncpus",
-  1))
+  1), ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -18,6 +18,8 @@ argument \code{dependencies} of \code{\link{install.packages}}.}
 \item{threads}{number of concurrent threads to use for installing
 dependencies.
 It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
+
+\item{...}{additional arguments passed to \code{\link{install.packages}}}
 }
 \description{
 Install package dependencies


### PR DESCRIPTION
This allows you to pass all arguments to `install.packages` if needed.

Motivation for this is to be able to set a alternate repo argument for `install_deps`, for instance to use `devtools::install()` to automatically install dependencies for a bioconductor package.

```r
install(repos = BiocInstaller::biocinstallRepos(), dependencies = TRUE)
```