### PR TITLE
Have travis build the vignettes by default

### DIFF
--- a/inst/templates/travis.yml
+++ b/inst/templates/travis.yml
@@ -16,7 +16,9 @@ after_failure:
   - ./travis-tool.sh dump_logs
 
 env:
-  - WARNINGS_ARE_ERRORS=1
+  global:
+    - WARNINGS_ARE_ERRORS=1
+    - R_BUILD_ARGS="--no-manual"
 
 notifications:
   email:


### PR DESCRIPTION
This simply adds to the `env` section of the default .travis.yml template: 

```
R_BUILD_ARGS="--no-manual"
```

so that Travis builds the vignettes.  

Currently, any time users have an `.Rmd` vignette in `vignettes` without the corresponding html/pdf in `inst/doc`, they will pass `devtools::check()` locally but get the notoriously cryptic warning 

```
Package vignette without corresponding PDF/HTML:
```

and a failed Travis status given that warnings are set to act as errors.  Googling the error will only tell them "you should build the package before testing it".  This change says tells travis to just ignore building the manual (since that would need bootstrap-latex, sad sad), but alter the default travis-r setting of not building vignettes.  

When building vignettes always meant needing BOOTSTRAP_LATEX on travis ci, which is terribly slow since travis has to do this from binary, the default of `--no-build-vignettes --no-manual` made more sense.
With nice HTML vignettes that won't need latex installed just to build the package, it seems that we may as well have travis actually build the vignettes.  Of course this doubles as a nice check on the vignettes themselves, and encourages the use of HTML vignettes.  All nice things, yes?  