### PR TITLE
Update .travis.yml for native R support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,27 @@
-language: c
-script: ./travis-tool.sh run_tests
+language: r
+warnings_are_errors: true
 
-after_failure:
-  - ./travis-tool.sh dump_logs
+r_packages:
+  - RUnit
+r_binary_packages:
+  - XML
+  - Rcpp
+  - knitr
+  - brew
+  - inline
+  - highlight
+  - formatR
+  - highr
+  - markdown
+  - rgl
+r_github_packages:
+  - rstudio/rmarkdown
+  - hadley/testthat
 
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-  - ./travis-tool.sh r_binary_install XML Rcpp knitr brew RUnit inline highlight formatR highr markdown rgl
-  - ./travis-tool.sh install_github rstudio/rmarkdown
-install:
-  - ./travis-tool.sh install_deps
-  # Install testthat after running install_deps, otherwise devtools itself might be installed from CRAN or c2d4u
-  - ./travis-tool.sh install_github hadley/testthat
 notifications:
   email:
     on_success: change
     on_failure: change
 env:
   - global:
-    - WARNINGS_ARE_ERRORS=1
     - _R_CHECK_FORCE_SUGGESTS_=0
-    - BOOTSTRAP_LATEX=1


### PR DESCRIPTION
This modifies the old config to use the native R support.

Note that the old config was careful about ordering of installation in order to ensure that we were using the cloned devtools. I've been more naive about that, but IIUC we're still testing the right thing: https://travis-ci.org/craigcitro/devtools/builds/52301857

If I'm missing something, maybe the right thing to do is to just run a manual `remove.packages` in the `before_script`?