### PR TITLE
Test dots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * `system_check()` combines arguments with ` `, not `, `. (#753)
 
 * `lint()` gains a `cache` argument (@jimhester, #708).
+* `test()` gains an `...` argument so that additional arguments can be passed
+  to `testthat::test_dir` (@jimhester, #747)
 
 * export functions `RCMD()` and `system_check()` so they can be used by other 
   packages. (@jimhester, #699).

--- a/R/test.r
+++ b/R/test.r
@@ -12,10 +12,11 @@
 #'
 #' @param pkg package description, can be path or package name. See
 #'   \code{\link{as.package}} for more information
+#' @param ... additional arguments passed to \code{\link[testthat]{test_dir}}
 #' @inheritParams testthat::test_dir
 #' @inheritParams run_examples
 #' @export
-test <- function(pkg = ".", filter = NULL) {
+test <- function(pkg = ".", filter = NULL, ...) {
   check_testthat()
   pkg <- as.package(pkg)
 
@@ -46,7 +47,7 @@ test <- function(pkg = ".", filter = NULL) {
   Sys.sleep(0.05); flush.console() # Avoid misordered output in RStudio
 
   env <- new.env(parent = ns_env)
-  with_envvar(r_env_vars(), testthat::test_dir(test_path, filter = filter, env = env))
+  with_envvar(r_env_vars(), testthat::test_dir(test_path, filter = filter, env = env, ...))
 }
 
 find_test_dir <- function(path) {

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -4,7 +4,7 @@
 \alias{test}
 \title{Execute all \pkg{test_that} tests in a package.}
 \usage{
-test(pkg = ".", filter = NULL)
+test(pkg = ".", filter = NULL, ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name. See
@@ -13,6 +13,8 @@ test(pkg = ".", filter = NULL)
 \item{filter}{If not \code{NULL}, only tests with file names matching this
 regular expression will be executed.  Matching will take on the file
 name after it has been stripped of \code{"test-"} and \code{".r"}.}
+
+\item{...}{additional arguments passed to \code{\link[testthat]{test_dir}}}
 }
 \description{
 Tests are assumed to be located in either the \code{inst/tests/} or


### PR DESCRIPTION
Pass ellipsis to testthat::test_dir to allow filtering options

As enabled by hadley/testthat#188

This allows you to use any of the options for `grepl()` from `devtools::test()`, `perl = TRUE`, `inverse = TRUE`, ect.