### PR TITLE
Fix/install GitHub submodule warn

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.7.1.9000
 
+* warn users of `install_github()` if repository contains submodules
+  that install may not function as expected (@ashander, #751).
+
 * export functions `RCMD()` and `system_check()` so they can be used by other 
   packages. (@jimhester, #699).
 

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -26,8 +26,8 @@
 #' raises a warning. Because the zipped sources provided by GitHub do not
 #' include submodules, this may lead to unexpected behaviour or compilation
 #' failure in source packages. In this case, cloning the repository manually
-#' using \code{git clone --recursive} and installing with \code{\link{install}}
-#' may yield better results.
+#' using \code{\link{install_git}} with \code{args="--recursive"} may yield
+#' better results.
 #' @export
 #' @family package installation
 #' @seealso \code{\link{github_pull}}

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -106,10 +106,10 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
   } else {
     auth <- NULL
   }
-  ## if repo uses submodules warn user
   submod <- download_text(src_submodules, auth)
-  if(grepl("\\.gitmodules", submod))
-      warning("Github repo contains submodules, may not function as expected!")
+  if (grepl("\\.gitmodules", submod))
+    warning("Github repo contains submodules, may not function as expected!",
+            call. = FALSE)
 
   download(dest, src, auth)
 }

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -107,12 +107,9 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
     auth <- NULL
   }
   ## if repo uses submodules warn user
-  request <- httr::GET(src_submodules, auth)
-  httr::stop_for_status(request)
-  submod <- httr::content(request, "text")
+  submod <- download_text(src_submodules, auth)
   if(grepl("\\.gitmodules", submod))
-      warning("Github repo ", x$username, "/", x$repo, "@", x$ref,
-              " contains submodules and may not function as expected!")
+      warning("Github repo contains submodules, may not function as expected!")
 
   download(dest, src, auth)
 }

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -21,6 +21,13 @@
 #' @param host Github API host to use. Override with your github enterprise
 #'   hostname, for example, \code{"github.hostname.com/api/v3"}.
 #' @param ... Other arguments passed on to \code{\link{install}}.
+#' @details
+#' Attempting to install from a source repository that uses submodules
+#' raises a warning. Because the zipped sources provided by GitHub do not
+#' include submodules, this may lead to unexpected behaviour or compilation
+#' failure in source packages. In this case, cloning the repository manually
+#' using \code{git clone --recursive} and installing with \code{\link{install}}
+#' may yield better results.
 #' @export
 #' @family package installation
 #' @seealso \code{\link{github_pull}}

--- a/R/utils.r
+++ b/R/utils.r
@@ -76,6 +76,12 @@ download <- function(path, url, ...) {
   path
 }
 
+download_text <- function(url, ...) {
+  request <- httr::GET(url, ...)
+  httr::stop_for_status(request)
+  httr::content(request, "text")
+}
+
 last <- function(x) x[length(x)]
 
 # Modified version of utils::file_ext. Instead of always returning the text

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -37,6 +37,14 @@ hostname, for example, \code{"github.hostname.com/api/v3"}.}
 This function is vectorised on \code{repo} so you can install multiple
 packages in a single command.
 }
+\details{
+Attempting to install from a source repository that uses submodules
+raises a warning. Because the zipped sources provided by GitHub do not
+include submodules, this may lead to unexpected behaviour or compilation
+failure in source packages. In this case, cloning the repository manually
+using \code{git clone --recursive} and installing with \code{\link{install}}
+may yield better results.
+}
 \examples{
 \dontrun{
 install_github("klutometis/roxygen")

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -42,8 +42,8 @@ Attempting to install from a source repository that uses submodules
 raises a warning. Because the zipped sources provided by GitHub do not
 include submodules, this may lead to unexpected behaviour or compilation
 failure in source packages. In this case, cloning the repository manually
-using \code{git clone --recursive} and installing with \code{\link{install}}
-may yield better results.
+using \code{\link{install_git}} with \code{args="--recursive"} may yield
+better results.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-github.r
+++ b/tests/testthat/test-github.r
@@ -72,23 +72,23 @@ test_that("GitHub references are resolved correctly", {
 })
 
 mock_install_remote <- function(remote, ..., quiet = FALSE) {
-    remote_download(remote, quiet = quiet)
-    return(TRUE)
+  remote_download(remote, quiet = quiet)
+  return(TRUE)
 }
 mock_download <- function(dest, src, ...)
-    return("")
+  return("")
 mock_download_text_true <- function(url, auth, ...)
-    return(".gitmodules")
+  return(".gitmodules")
 mock_download_text_false <- function(url, auth, ...)
-    return("{resource:  not located}")
+  return("{resource:  not located}")
 test_that("GitHub repos that contain submodules raise warning", {
-    with_mock("install_remote", mock_install_remote, {
-        with_mock("download", mock_download, {
-            with_mock("download_text", mock_download_text_false,
-                      expect_that(install_github("hadley/devtools"), not(gives_warning())))
-            with_mock("download_text", mock_download_text_true,
-                      expect_that(install_github("hadley/devtools"),
-                                  gives_warning("Github repo contains submodules, may not function as expected!")))
+  with_mock("install_remote", mock_install_remote, {
+    with_mock("download", mock_download, {
+      with_mock("download_text", mock_download_text_false,
+                expect_that(install_github("hadley/devtools"), not(gives_warning())))
+      with_mock("download_text", mock_download_text_true,
+                expect_that(install_github("hadley/devtools"),
+                            gives_warning("Github repo contains submodules, may not function as expected!")))
         })
     })
 })

--- a/tests/testthat/test-github.r
+++ b/tests/testthat/test-github.r
@@ -69,7 +69,7 @@ test_that("GitHub references are resolved correctly", {
     expect_equal(github_resolve_ref(github_pull(123), default_params)$ref, "some-pull-request")
     expect_equal(github_resolve_ref(github_release(), default_params)$ref, "some-release")
   })
-}
+})
 
 mock_install_remote <- function(remote, ..., quiet = FALSE) {
     remote_download(remote, quiet = quiet)


### PR DESCRIPTION
Add warning when downloading from github repo that uses submodules 
(assessed through presence of .gitsubmodules file). 

Help for install_github updated to suggest use of install_git with proper args in this case.

Limited testing (with mock responses from download and attempt to download .gitsubmodules).

Partially responsive to #737