### PR TITLE
travis.yml - sudo: required (#749)

### DIFF
--- a/inst/templates/travis.yml
+++ b/inst/templates/travis.yml
@@ -2,6 +2,7 @@
 
 language: r
 warnings_are_errors: true
+sudo: required
 
 notifications:
   email:


### PR DESCRIPTION
It seems to be, this evening.

In the world's weakest pull request, I have added 'sudo: required' to the travis.yml template.