### PR TITLE
install revdep packages manually

### DIFF
--- a/R/revdep.R
+++ b/R/revdep.R
@@ -119,6 +119,7 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
   message("Finding reverse dependencies")
   pkgs <- revdep(pkg$package, recursive = recursive, ignore = ignore,
     bioconductor = bioconductor, dependencies = dependencies)
+  install.packages(pkgs, dependencies = NA)
   res <- check_cran(pkgs, revdep_pkg = pkg$package, libpath = libpath,
     srcpath = srcpath, bioconductor = bioconductor, type = type,
     threads = threads, check_dir = check_dir)

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -119,7 +119,7 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
   message("Finding reverse dependencies")
   pkgs <- revdep(pkg$package, recursive = recursive, ignore = ignore,
     bioconductor = bioconductor, dependencies = dependencies)
-  install.packages(pkgs, dependencies = NA)
+  install.packages(pkgs, lib = libpath, dependencies = NA)
   res <- check_cran(pkgs, revdep_pkg = pkg$package, libpath = libpath,
     srcpath = srcpath, bioconductor = bioconductor, type = type,
     threads = threads, check_dir = check_dir)


### PR DESCRIPTION
because revdep returns a sorted list, and the packages may depend upon each other if recursive = TRUE