### PR TITLE
fix unzip ambiguity

### DIFF
--- a/R/build-github-devtools.r
+++ b/R/build-github-devtools.r
@@ -49,7 +49,7 @@ build_github_devtools <- function(outfile = NULL) {
   writeBin(httr::content(request, "raw"), bundle)
   on.exit(unlink(bundle))
 
-  unzip(bundle, exdir = tempdir())
+  utils::unzip(bundle, exdir = tempdir())
 
   # Build binary package
   pkgdir <- file.path(tempdir(), "devtools-master")


### PR DESCRIPTION
An attempt to address https://github.com/hadley/devtools/issues/761 (edit: turns out my devtools was out of date, but the `unzip` utility is gone from devtools so this should be necessary regardless)