### PR TITLE
Hotfix: demand text from github api

### DIFF
--- a/R/install-github.r
+++ b/R/install-github.r
@@ -106,10 +106,8 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
   } else {
     auth <- NULL
   }
-
-  x <- httr::HEAD(src_submodules, auth)
-  has_submods <- identical(httr::status_code(x), 200L)
-  if (has_submods)
+  submod <- get_text(src_submodules, auth)
+  if (grepl("\\.gitmodules", submod))
     warning("Github repo contains submodules, may not function as expected!",
       call. = FALSE)
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -87,6 +87,11 @@ download_text <- function(url, ...) {
   httr::content(request, "text")
 }
 
+get_text <- function(url, ...) {
+  request <- httr::GET(url, ...)
+  httr::content(request, "text")
+}
+
 last <- function(x) x[length(x)]
 
 # Modified version of utils::file_ext. Instead of always returning the text

--- a/tests/testthat/test-github.r
+++ b/tests/testthat/test-github.r
@@ -84,9 +84,9 @@ mock_download_text_false <- function(url, auth, ...)
 test_that("GitHub repos that contain submodules raise warning", {
   with_mock("install_remote", mock_install_remote, {
     with_mock("download", mock_download, {
-      with_mock("download_text", mock_download_text_false,
+      with_mock("get_text", mock_download_text_false,
                 expect_that(install_github("hadley/devtools"), not(gives_warning())))
-      with_mock("download_text", mock_download_text_true,
+      with_mock("get_text", mock_download_text_true,
                 expect_that(install_github("hadley/devtools"),
                             gives_warning("Github repo contains submodules, may not function as expected!")))
         })


### PR DESCRIPTION
Alternative approach to dee7b7

Write an extra utils function that demands text from the github API even with 404. This integrates more easily with testing for this enhancement.

Conflicts:
	R/install-github.r