### PR TITLE
spell-check package description

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,9 @@
 
 * `NOT_CRAN` envvar no longer overrides externally set variable.
 
+* `check(check_version = TRUE)` also checks spelling of the `DESCRIPTION`; if no
+  spell checker is installed, a warning is given (#784, @krlmlr).
+
 # devtools 1.7.0
 
 ## Improve reverse dependency checking

--- a/R/check.r
+++ b/R/check.r
@@ -111,7 +111,7 @@ check_r_cmd <- function(built_path = NULL, cran = TRUE, check_version = FALSE,
   # not set, R CMD check will use the defaults as described in R Internals.
   env_vars <- c(
     if (cran) cran_env_vars(),
-    if (check_version) c("_R_CHECK_CRAN_INCOMING_" = "TRUE"),
+    if (check_version) c("_R_CHECK_CRAN_INCOMING_" = "TRUE", aspell_env_var()),
     if (!force_suggests) c("_R_CHECK_FORCE_SUGGESTS_" = "FALSE")
   )
 
@@ -152,7 +152,6 @@ cran_env_vars <- function() {
     "_R_CHECK_TOPLEVEL_FILES_"           = "TRUE",
     "_R_CHECK_S3_METHODS_NOT_REGISTERED_"= "TRUE",
     "_R_CHECK_OVERWRITE_REGISTERED_S3_METHODS_" = "TRUE",
-    aspell_env_var(),
     # The following are used for CRAN incoming checks according to the R
     # internals doc, but they're not in the list at the bottom of the Tools
     # section (have to look at the description of the individual env vars).

--- a/R/check.r
+++ b/R/check.r
@@ -168,7 +168,7 @@ aspell_env_var <- function() {
       c("_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "TRUE")
     },
     error = function(e) {
-      warning(e$message, call. = FALSE)
+      warning("Skipping spell check: ", e$message, call. = FALSE)
       NULL
     }
   )

--- a/R/check.r
+++ b/R/check.r
@@ -152,6 +152,7 @@ cran_env_vars <- function() {
     "_R_CHECK_TOPLEVEL_FILES_"           = "TRUE",
     "_R_CHECK_S3_METHODS_NOT_REGISTERED_"= "TRUE",
     "_R_CHECK_OVERWRITE_REGISTERED_S3_METHODS_" = "TRUE",
+    "_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "TRUE",
     # The following are used for CRAN incoming checks according to the R
     # internals doc, but they're not in the list at the bottom of the Tools
     # section (have to look at the description of the individual env vars).

--- a/R/check.r
+++ b/R/check.r
@@ -152,11 +152,24 @@ cran_env_vars <- function() {
     "_R_CHECK_TOPLEVEL_FILES_"           = "TRUE",
     "_R_CHECK_S3_METHODS_NOT_REGISTERED_"= "TRUE",
     "_R_CHECK_OVERWRITE_REGISTERED_S3_METHODS_" = "TRUE",
-    "_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "TRUE",
+    aspell_env_var(),
     # The following are used for CRAN incoming checks according to the R
     # internals doc, but they're not in the list at the bottom of the Tools
     # section (have to look at the description of the individual env vars).
     "_R_CHECK_RD_LINE_WIDTHS_"           = "TRUE",
     "_R_CHECK_LIMIT_CORES_"              = "TRUE"
+  )
+}
+
+aspell_env_var <- function() {
+  tryCatch(
+    {
+      utils::aspell(NULL)
+      c("_R_CHECK_CRAN_INCOMING_USE_ASPELL_" = "TRUE")
+    },
+    error = function(e) {
+      warning(e$message, call. = FALSE)
+      NULL
+    }
   )
 }

--- a/R/check.r
+++ b/R/check.r
@@ -47,6 +47,10 @@
 #' @param check_version if \code{TRUE}, check that the new version is greater
 #'   than the current version on CRAN, by setting the
 #'   \code{_R_CHECK_CRAN_INCOMING_} environment variable to \code{TRUE}.
+#'   (This also enables spell checking of the package's \code{DESCRIPTION}
+#'   by setting the \code{_R_CHECK_CRAN_INCOMING_USE_ASPELL_} environment
+#'   variable to \code{TRUE}; if no spell checker is installed, a warning is
+#'   issued.)
 #' @param force_suggests if \code{FALSE}, don't force suggested packages, by
 #'   setting the \code{_R_CHECK_FORCE_SUGGESTS_} environment variable to
 #'   \code{FALSE}.

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -1,0 +1,12 @@
+context("Check")
+
+test_that("aspell environment variables", {
+  with_mock(
+    `utils:::aspell_find_program` = function (...) "/bin/aspell",
+    expect_equal(names(aspell_env_var()), "_R_CHECK_CRAN_INCOMING_USE_ASPELL_")
+  )
+  with_mock(
+    `utils:::aspell_find_program` = function (...) NA,
+    expect_warning(aspell_env_var(), "Skipping spell check")
+  )
+})


### PR DESCRIPTION
Is active only with `check(cran = TRUE, check_version = TRUE)`. Emits a warning if no spell checker is found (checked via `utils::aspell(NULL)` because the worker function `utils:::aspell_find_program` is not exported).

R source reference: https://github.com/wch/r-source/blob/deb67e31fd0106dae7ab0d274ab874e56ab1b7b5/src/library/tools/R/QC.R#L6517