### PR TITLE
Minor update to use_cran_badge

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -583,11 +583,9 @@ union_write <- function(path, new_lines) {
 #' @export
 use_cran_badge <- function(pkg = ".") {
   pkg <- as.package(pkg)
-
-  gh <- github_info(pkg$path)
   message(
     " * Add a CRAN status shield by adding the following line to your README:\n",
-    "[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/", gh$repo, ")](http://cran.r-project.org/web/packages/", gh$repo, ")"
+    "[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/", pkg$package, ")](http://cran.r-project.org/web/packages/", pkg$package, ")"
   )
   invisible(TRUE)
 }


### PR DESCRIPTION
@gaborcsardi noted that gh repo name might not always match package name. This small change should fix that.
