### PR TITLE
Don't use package root for create_description

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -193,7 +193,7 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 #' @export
 create_description <- function(path = ".", extra = getOption("devtools.desc"),
                                quiet = FALSE) {
-  path <- check_dir(path)
+  # Don't call check_dir(path) here (#803)
   desc_path <- file.path(path, "DESCRIPTION")
 
   if (file.exists(desc_path)) return(FALSE)


### PR DESCRIPTION
Otherwise, it's impossible to create/setup a package in a subdirectory of an existing package.

(Sorry for the other bogus pull request.)