### PR TITLE
A small format modification

### DIFF
--- a/R/check.r
+++ b/R/check.r
@@ -48,7 +48,7 @@
 #'   than the current version on CRAN, by setting the
 #'   \code{_R_CHECK_CRAN_INCOMING_} environment variable to \code{TRUE}.
 #'   (This also enables spell checking of the package's \code{DESCRIPTION}
-#'   by setting the \code{_R_CHECK_CRAN_INCOMING_USE_ASPELL_} environment
+#'   by setting the "_R_CHECK_CRAN_INCOMING_USE_ASPELL_" environment
 #'   variable to \code{TRUE}; if no spell checker is installed, a warning is
 #'   issued.)
 #' @param force_suggests if \code{FALSE}, don't force suggested packages, by

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -26,7 +26,7 @@ CRAN uses.}
 than the current version on CRAN, by setting the
 \code{_R_CHECK_CRAN_INCOMING_} environment variable to \code{TRUE}.
 (This also enables spell checking of the package's \code{DESCRIPTION}
-by setting the \code{_R_CHECK_CRAN_INCOMING_USE_ASPELL_} environment
+by setting the "_R_CHECK_CRAN_INCOMING_USE_ASPELL_" environment
 variable to \code{TRUE}; if no spell checker is installed, a warning is
 issued.)}
 


### PR DESCRIPTION
In the /argument part of the check.Rd file (in /man folder), I made a small modification on the item "check_version".
The previous code will cause display error in the Page 7 of the PDF manual generated. It was truncated automatically as below:
![image](https://cloud.githubusercontent.com/assets/11539188/7787025/60dd10de-0226-11e5-8dc3-dbc91cf52aac.png)

To confirm, you may want to have a check at the online PDF manual: http://cran.r-project.org/web/packages/devtools/devtools.pdf