### PR TITLE
install up-to-date lintr from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ r_github_packages:
   - rstudio/rmarkdown
   - hadley/testthat
   - jimhester/covr
+  - jimhester/lintr
 
 bioc_packages:
   - BiocInstaller


### PR DESCRIPTION
Example for failing test: https://travis-ci.org/krlmlr/devtools/builds/64078115#L1608