### PR TITLE
build_vignettes() gains dependencies argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix use of `uses_git()` in `use_readme_rmd()` (#793).
 
+* `build_vignettes()` gains dependencies argument (#825, @krlmlr).
+
 # devtools 1.8.0
  
 ## Helpers

--- a/R/vignettes.r
+++ b/R/vignettes.r
@@ -8,17 +8,18 @@
 #'
 #' @param pkg package description, can be path or package name.  See
 #'   \code{\link{as.package}} for more information
+#' @inheritParams install_deps
 #' @keywords programming
 #' @seealso \code{\link{clean_vignettes}} to remove the pdfs in
 #'   \file{inst/doc} created from vignettes
 #' @export
 #' @seealso \code{\link{clean_vignettes}} to remove build tex/pdf files.
-build_vignettes <- function(pkg = ".") {
+build_vignettes <- function(pkg = ".", dependencies = "VignetteBuilder") {
   pkg <- as.package(pkg)
   vigns <- tools::pkgVignettes(dir = pkg$path)
   if (length(vigns$docs) == 0) return()
 
-  install_deps(pkg, "VignetteBuilder")
+  install_deps(pkg, dependencies)
 
   message("Building ", pkg$package, " vignettes")
   tools::buildVignettes(dir = pkg$path, tangle = TRUE)

--- a/man/build_vignettes.Rd
+++ b/man/build_vignettes.Rd
@@ -4,11 +4,15 @@
 \alias{build_vignettes}
 \title{Build package vignettes.}
 \usage{
-build_vignettes(pkg = ".")
+build_vignettes(pkg = ".", dependencies = "VignetteBuilder")
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
 \code{\link{as.package}} for more information}
+
+\item{dependencies}{\code{logical} indicating to also install uninstalled
+packages which this \code{pkg} depends on/links to/suggests. See
+argument \code{dependencies} of \code{\link{install.packages}}.}
 }
 \description{
 Builds package vignettes using the same algorithm that \code{R CMD build}

--- a/tests/testthat/test-vignettes.r
+++ b/tests/testthat/test-vignettes.r
@@ -52,6 +52,20 @@ if (packageVersion("knitr") >= 1.2) {
     expect_false("test.R" %in% dir(doc_path))
     expect_false("test.Rmd" %in% dir(doc_path))
   })
+
+  test_that("dependencies argument", {
+    pkg <- as.package("testMarkdownVignettes")
+    doc_path <- file.path(pkg$path, "inst", "doc")
+
+    clean_vignettes(pkg)
+    on.exit(clean_vignettes(pkg), add = TRUE)
+    installed_deps <- NULL
+    with_mock(
+      install_deps = function(pkg, dependencies) installed_deps <<- dependencies,
+      build_vignettes(pkg, FALSE)
+    )
+    expect_false(installed_deps)
+  })
 }
 
 


### PR DESCRIPTION
Passed to `install_deps()`.

Use case: run `build_vignettes(dependencies = FALSE)` in tests