### PR TITLE
with_lib resets library path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
   reads compilation variables from the Makevars rather than the environment
   (@jimhester, #788).
 
+* Properly reset library path after `with_lib()` (#836, @krlmlr).
+
 # devtools 1.8.0
  
 ## Helpers

--- a/R/with.r
+++ b/R/with.r
@@ -130,9 +130,13 @@ set_libpaths <- function(paths) {
   invisible(old)
 }
 
+reset_libpaths <- function(paths) {
+  .libPaths(paths)
+}
+
 #' @rdname with_something
 #' @export
-with_libpaths <- with_something(set_libpaths)
+with_libpaths <- with_something(set_libpaths, reset_libpaths)
 
 # lib ------------------------------------------------------------------------
 
@@ -146,7 +150,7 @@ set_lib <- function(paths) {
 
 #' @rdname with_something
 #' @export
-with_lib <- with_something(set_lib)
+with_lib <- with_something(set_lib, reset_libpaths)
 
 # options --------------------------------------------------------------------
 

--- a/R/with.r
+++ b/R/with.r
@@ -34,8 +34,6 @@
 NULL
 
 with_something <- function(set, reset = set) {
-  force(set)
-  force(reset)
   function(new, code) {
     old <- set(new)
     on.exit(reset(old))

--- a/R/with.r
+++ b/R/with.r
@@ -33,11 +33,12 @@
 #' )
 NULL
 
-with_something <- function(set) {
+with_something <- function(set, reset = set) {
   force(set)
+  force(reset)
   function(new, code) {
     old <- set(new)
-    on.exit(set(old))
+    on.exit(reset(old))
     force(code)
   }
 }

--- a/R/with.r
+++ b/R/with.r
@@ -34,6 +34,7 @@
 NULL
 
 with_something <- function(set) {
+  force(set)
   function(new, code) {
     old <- set(new)
     on.exit(set(old))

--- a/tests/testthat/test-with.r
+++ b/tests/testthat/test-with.r
@@ -41,3 +41,23 @@ test_that("with_options works", {
   expect_equal(with_options(c(zyxxyzyx="qwrbbl"), getOption("zyxxyzyx")), "qwrbbl")
   expect_that(getOption("zyxxyzyx"), not(equals("qwrbbl")))
 })
+
+test_that("with_lib works and resets library", {
+  lib <- .libPaths()
+  new_lib <- "."
+  with_lib(
+    new_lib,
+    expect_true(normalizePath(new_lib) %in% .libPaths())
+  )
+  expect_equal(lib, .libPaths())
+})
+
+test_that("with_libpaths works and resets library", {
+  lib <- .libPaths()
+  new_lib <- "."
+  with_libpaths(
+    new_lib,
+    expect_true(normalizePath(new_lib) %in% .libPaths())
+  )
+  expect_equal(lib, .libPaths())
+})

--- a/tests/testthat/test-with.r
+++ b/tests/testthat/test-with.r
@@ -61,3 +61,16 @@ test_that("with_libpaths works and resets library", {
   )
   expect_equal(lib, .libPaths())
 })
+
+test_that("with_something works", {
+  res <- NULL
+  set <- function(new) {
+    res <<- c(res, 1L)
+  }
+  reset <- function(old) {
+    res <<- c(res, 3L)
+  }
+  with_res <- with_something(set, reset)
+  with_res(NULL, res <- c(res, 2L))
+  expect_equal(res, 1L:3L)
+})


### PR DESCRIPTION
- Reset library path after `with_lib()`
- Includes test that fails without this modification

Closes #833, I'm planning to implement the `with_temp_lib()` function largely from scratch.