### PR TITLE
Add forward slashes to Contributor Covenant URL in CONDUCT.md

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -21,5 +21,5 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 opening an issue or contacting one or more of the project maintainers.
 
 This Code of Conduct is adapted from the Contributor Covenant 
-(http:contributor-covenant.org), version 1.0.0, available at 
+(http://contributor-covenant.org), version 1.0.0, available at 
 http://contributor-covenant.org/version/1/0/0/


### PR DESCRIPTION
The link to [contributor-covenant.org](http://contributor-covenant.org/) had no forward slashes and so doesn't show up as a link on GitHub.