### PR TITLE
as.package and load_all gain new argument 'create'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,9 @@
 
 * `uses_testthat()` and `check_failures()` are now exported (#824, #839, @krlmlr).
 
-* Remove explicit `library(testthat)` call in `test()` (#798, @krlmlr)
+* Remove explicit `library(testthat)` call in `test()` (#798, @krlmlr).
+
+* `as.package` and `load_all` gain new argument `create`. Like other functions with a `pkg` argument, `load_all` looks for a `DESCRIPTION` file in parent directories (#852, @krlmlr).
 
 # devtools 1.8.0
  

--- a/R/load.r
+++ b/R/load.r
@@ -51,10 +51,7 @@
 #' a perfect replacement for \code{base::system.file}.
 #'
 #' @param pkg package description, can be path or package name.  See
-#'   \code{\link{as.package}} for more information. If the \code{DESCRIPTION}
-#'   file does not exist, it is created using \code{\link{create_description}}.
-#'   (This means that only the precise path to the package, but not to a
-#'   subdirectory in the package, are accepted here.)
+#'   \code{\link{as.package}} for more information.
 #' @param reset clear package environment and reset file cache before loading
 #'   any pieces of the package. This is equivalent to running
 #'   \code{\link{unload}} and is the default. Use \code{reset = FALSE} may be
@@ -67,6 +64,7 @@
 #'   If \code{FALSE}, export only the objects that are listed as exports
 #'   in the NAMESPACE file.
 #' @param quiet if \code{TRUE} suppresses output from this function.
+#' @inheritParams as.package
 #' @keywords programming
 #' @examples
 #' \dontrun{
@@ -85,12 +83,9 @@
 #' }
 #' @export
 load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
-  export_all = TRUE, quiet = FALSE) {
+  export_all = TRUE, quiet = FALSE, create = NA) {
 
-  if (!is.package(pkg)) {
-    create_description(pkg)
-    pkg <- as.package(pkg)
-  }
+  pkg <- as.package(pkg, create = create)
 
   if (!quiet) message("Loading ", pkg$package)
 

--- a/R/package.r
+++ b/R/package.r
@@ -101,4 +101,5 @@ load_pkg_description <- function(path, create) {
 #' @export
 is.package <- function(x) inherits(x, "package")
 
-
+# Mockable variant of interactive
+interactive <- function() .Primitive("interactive")()

--- a/man/as.package.Rd
+++ b/man/as.package.Rd
@@ -4,10 +4,14 @@
 \alias{as.package}
 \title{Coerce input to a package.}
 \usage{
-as.package(x = NULL)
+as.package(x = NULL, create = NA)
 }
 \arguments{
 \item{x}{object to coerce to a package}
+
+\item{create}{only relevant if a package structure does not exist yet: if
+\code{TRUE}, create a package structure; if \code{NA}, ask the user
+(in interactive mode only)}
 }
 \description{
 Possible specifications of package:

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -5,14 +5,11 @@
 \title{Load complete package.}
 \usage{
 load_all(pkg = ".", reset = TRUE, recompile = FALSE, export_all = TRUE,
-  quiet = FALSE)
+  quiet = FALSE, create = NA)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
-\code{\link{as.package}} for more information. If the \code{DESCRIPTION}
-file does not exist, it is created using \code{\link{create_description}}.
-(This means that only the precise path to the package, but not to a
-subdirectory in the package, are accepted here.)}
+\code{\link{as.package}} for more information.}
 
 \item{reset}{clear package environment and reset file cache before loading
 any pieces of the package. This is equivalent to running
@@ -29,6 +26,10 @@ If \code{FALSE}, export only the objects that are listed as exports
 in the NAMESPACE file.}
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
+
+\item{create}{only relevant if a package structure does not exist yet: if
+\code{TRUE}, create a package structure; if \code{NA}, ask the user
+(in interactive mode only)}
 }
 \description{
 \code{load_all} loads a package. It roughly simulates what happens

--- a/tests/testthat/test-load.r
+++ b/tests/testthat/test-load.r
@@ -7,6 +7,7 @@ test_that("Package root and subdirectory is working directory when loading", {
 
 test_that("user is queried if no package structure present", {
   with_mock(
+    `devtools::interactive` = function() TRUE,
     `utils::menu` = function(...) stop("menu() called"),
     `devtools::setup` = function(...) stop("setup() called"),
     `devtools::check_dir` = function(x) x,

--- a/tests/testthat/test-load.r
+++ b/tests/testthat/test-load.r
@@ -1,10 +1,47 @@
 context("Loading")
 
-test_that("Package root is working directory when loading", {
+test_that("Package root and subdirectory is working directory when loading", {
   expect_message(load_all("testLoadDir"), "[|].*/testLoadDir[|]")
+  expect_message(load_all(file.path("testLoadDir", "R")), "[|].*/testLoadDir[|]")
 })
 
-test_that("Loading a package subdirectory throws an error", {
-  expect_error(load_all(file.path("testLoadDir", "R")),
-               "does not look like a package")
+test_that("user is queried if no package structure present", {
+  with_mock(
+    `utils::menu` = function(...) stop("menu() called"),
+    `devtools::setup` = function(...) stop("setup() called"),
+    `devtools::check_dir` = function(x) x,
+    expect_error(load_all(file.path("testLoadDir", "R")),
+                 "menu[(][)] called")
+  )
+})
+
+test_that("setup is called upon user consent if no package structure present", {
+  with_mock(
+    `devtools::interactive` = function() TRUE,
+    `utils::menu` = function(choices, ...) match("Yes", choices),
+    `devtools::setup` = function(...) stop("setup() called"),
+    `devtools::check_dir` = function(x) x,
+    expect_error(load_all(file.path("testLoadDir", "R")),
+                 "setup[(][)] called")
+  )
+})
+
+test_that("setup is called if no package structure present", {
+  with_mock(
+    `utils::menu` = function(...) stop("menu() called"),
+    `devtools::setup` = function(...) stop("setup() called"),
+    `devtools::check_dir` = function(x) x,
+    expect_error(load_all(file.path("testLoadDir", "R"), create = TRUE),
+               "setup[(][)] called")
+  )
+})
+
+test_that("error is thrown if no package structure present", {
+  with_mock(
+    `utils::menu` = function(...) stop("menu() called"),
+    `devtools::setup` = function(...) stop("setup() called"),
+    `devtools::check_dir` = function(x) x,
+    expect_error(load_all(file.path("testLoadDir", "R"), create = FALSE),
+                 "No description at")
+  )
 })


### PR DESCRIPTION
Governs if a package structure should be created if it is missing. If `NA`, the user is queried (in interactive mode only).

This also changes the semantics of `load_all()`: Now, a package is created only if no `DESCRIPTION` is found in the directory hierarchy, and only if requested or approved by the user. Any `DESCRIPTION` in a parent directoy will be used if found.

All relevant code paths tested.

Fixes #852.