### PR TITLE
Fix regressions on win-builder

### DIFF
--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -6,7 +6,10 @@ test_that("return messages", {
 
   on.exit(unlink(check_dir_name, recursive = TRUE), add = TRUE)
   with_envvar(
-    list("_R_CHECK_RD_XREFS_"="FALSE"),
+    list(
+      "_R_CHECK_RD_XREFS_"="FALSE",
+      "_R_CHECK_CRAN_INCOMING_"="FALSE"
+    ),
     check(pkg_name, document = FALSE, cran = FALSE,
           check_dir = ".", cleanup = FALSE, quiet = TRUE)
   )

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -10,7 +10,7 @@ test_that("return messages", {
 
   failures <- check_failures("testHelp.Rcheck", error = TRUE,
                              warning = TRUE, note = TRUE)
-  expect_equal(failures, character())
+  expect_equal(failures, character(), info = paste(failures, collapse = "\n"))
 })
 
 test_that("aspell environment variables", {

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -1,14 +1,17 @@
 context("Check")
 
 test_that("return messages", {
-  on.exit(unlink("testHelp.Rcheck", recursive = TRUE), add = TRUE)
+  pkg_name <- "testTest"
+  check_dir_name <- sprintf("%s.Rcheck", pkg_name)
+
+  on.exit(unlink(check_dir_name, recursive = TRUE), add = TRUE)
   with_envvar(
     list("_R_CHECK_RD_XREFS_"="FALSE"),
-    check("testHelp", document = FALSE, check_dir = ".", cleanup = FALSE,
-          quiet = TRUE)
+    check(pkg_name, document = FALSE, cran = FALSE,
+          check_dir = ".", cleanup = FALSE, quiet = TRUE)
   )
 
-  failures <- check_failures("testHelp.Rcheck", error = TRUE,
+  failures <- check_failures(check_dir_name, error = TRUE,
                              warning = TRUE, note = TRUE)
   expect_equal(failures, character(), info = paste(failures, collapse = "\n"))
 })

--- a/tests/testthat/testTest/DESCRIPTION
+++ b/tests/testthat/testTest/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: testTest
 Title: Tools to make developing R code easier
 License: GPL-2
-Description:
+Description: Package description.
 Author: Hadley <h.wickham@gmail.com>
 Maintainer: Hadley <h.wickham@gmail.com>
 Version: 0.1


### PR DESCRIPTION
Caused by too restrictive tests. Passes the previously failing test on win-builder now:

- R-devel: http://win-builder.r-project.org/B43aMx2dhNzO/
- R-stable: http://win-builder.r-project.org/Dgi7yJvgEZww/

Follow-up to #798.