### PR TITLE
Prepare for CRAN release

### DIFF
--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -1,6 +1,8 @@
 context("Check")
 
 test_that("return messages", {
+  skip_on_cran()
+
   pkg_name <- "testTest"
   check_dir_name <- sprintf("%s.Rcheck", pkg_name)
 

--- a/tests/testthat/test-test.r
+++ b/tests/testthat/test-test.r
@@ -7,6 +7,8 @@ test_that("Package can be tested with testthat not on search path", {
     on.exit(attach(testthat_env, testthat_pos), add = TRUE)
   }
 
-  test("testTest")
-  test("testTestWithDepends")
+  test("testTest", reporter = "stop")
+  expect_true(TRUE)
+  test("testTestWithDepends", reporter = "stop")
+  expect_true(TRUE)
 })


### PR DESCRIPTION
- silent test of test() function
- skip problematic test of check() on CRAN