### PR TITLE
Add env_var argument to check()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.0.9000
 
+* `check()` gains a `env_vars` argument to allow the user to set the
+  environment variables used in the check (#894, @jimhester).
+
 * Detect if `install_` commands are called on a Bioconductor package and
   include the Bioconductor repositories if they are not already set (#895,
   @jimhester).

--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -23,6 +23,8 @@
 #' @param revdep_pkg Optional name of a package for which this check is
 #'   checking the reverse dependencies of. This is normally passed in from
 #'   \code{\link{revdep_check}}, and is used only for logging.
+#' @param env_vars Optional additional environment variables to set.  Values
+#'   set here will override the defaults set by \code{\link{cran_env_vars}()}.
 #' @return Returns (invisibly) the directory where check results are stored.
 #' @keywords internal
 #' @export
@@ -31,7 +33,8 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
                        type = getOption("pkgType"),
                        threads = getOption("Ncpus", 1),
                        check_dir = tempfile("check_cran"),
-                       revdep_pkg = NULL) {
+                       revdep_pkg = NULL,
+                       env_vars = NULL) {
 
   stopifnot(is.character(pkgs))
   if (length(pkgs) == 0) return()
@@ -90,7 +93,8 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
       check_r_cmd(pkgs[i], local_urls[i],
         args = "--no-multiarch --no-manual --no-codoc",
         check_dir = check_dir,
-        quiet = TRUE
+        quiet = TRUE,
+        env_vars = env_vars
       )
     }, error = function(e) {
       message("Check failed: ", e$message)

--- a/R/check.r
+++ b/R/check.r
@@ -116,8 +116,6 @@ check_r_cmd <- function(built_path = NULL, cran = TRUE, check_version = FALSE,
 
   env_vars <- c(check_env_vars(cran, check_version, force_suggests), env_vars)
 
-  # remove duplicated vars, keeping only the last instance
-  env_vars <- env_vars[!duplicated(names(env_vars), fromLast = TRUE)]
   if (!quiet)
     show_env_vars(env_vars)
 

--- a/R/check.r
+++ b/R/check.r
@@ -96,16 +96,11 @@ check <- function(pkg = ".", document = TRUE, cleanup = TRUE, cran = TRUE,
 # Run R CMD check and return the path for the check
 # @param built_path The path to the built .tar.gz source package.
 # @param check_dir The directory to unpack the .tar.gz file to
-<<<<<<< HEAD
-check_r_cmd <- function(name, built_path = NULL, cran = TRUE,
-                        check_version = FALSE, force_suggests = FALSE,
-                        args = NULL, check_dir = tempdir(), quiet = FALSE, ...) {
-=======
 # @param env_vars Optional additional environment variables to set.  Values
 #   set here will override the defaults set by \code{\link{cran_env_vars}()}.
 check_r_cmd <- function(built_path = NULL, cran = TRUE, check_version = FALSE,
-  force_suggests = TRUE, args = NULL, check_dir = tempdir(), env_vars = NULL, ...) {
->>>>>>> Add env_var argument to check()
+  force_suggests = TRUE, args = NULL, check_dir = tempdir(), quiet = FALSE,
+  env_vars = NULL, ...) {
 
   pkgname <- gsub("_.*?$", "", basename(built_path))
 
@@ -119,30 +114,16 @@ check_r_cmd <- function(built_path = NULL, cran = TRUE, check_version = FALSE,
     opts <- c("--as-cran", opts)
   }
 
-<<<<<<< HEAD
-  env_vars <- check_env_vars(cran, check_version, force_suggests)
+  env_vars <- c(check_env_vars(cran, check_version, force_suggests), env_vars)
+
+  # remove duplicated vars, keeping only the last instance
+  env_vars <- env_vars[!duplicated(names(env_vars), fromLast = TRUE)]
   if (!quiet)
     show_env_vars(env_vars)
 
   if (!quiet)
-    rule("Checking ", name)
+    rule("Checking ", pkgname)
   opts <- paste(paste(opts, collapse = " "), paste(args, collapse = " "))
-=======
-  opts <- paste(paste(opts, collapse = " "), paste(args, collapse = " "))
-
-  # Setting these environment variables requires some care because they can be
-  # be TRUE, FALSE, or not set. (And some variables take numeric values.) When
-  # not set, R CMD check will use the defaults as described in R Internals.
-  env_vars <- c(env_vars,
-    if (cran) cran_env_vars(),
-    if (check_version) c("_R_CHECK_CRAN_INCOMING_" = "TRUE", aspell_env_var()),
-    if (!force_suggests) c("_R_CHECK_FORCE_SUGGESTS_" = "FALSE")
-  )
-
-  # remove duplicated vars, keeping only the first instance
-  env_vars <- env_vars[!duplicated(names(env_vars))]
-
->>>>>>> Add env_var argument to check()
   R(paste("CMD check ", shQuote(built_path), " ", opts, sep = ""), check_dir,
     env_vars, quiet = quiet, ...)
 

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -87,6 +87,7 @@ print.maintainers <- function(x, ...) {
 #'
 #' @inheritParams revdep
 #' @param pkg Path to package. Defaults to current directory.
+#' @param ... Additional arguments passed to \code{\link{check_cran}()}
 #' @inheritParams check_cran
 #' @seealso \code{\link{revdep_maintainers}()} to run R CMD check on all reverse
 #'   dependencies.
@@ -108,7 +109,8 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
                          srcpath = libpath, bioconductor = FALSE,
                          type = getOption("pkgType"),
                          threads = getOption("Ncpus", 1),
-                         check_dir = tempfile("check_cran")) {
+                         check_dir = tempfile("check_cran"),
+                         ...) {
   pkg <- as.package(pkg)
   rule("Reverse dependency checks for ", pkg$package, pad = "=")
 
@@ -132,7 +134,7 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
     bioconductor = bioconductor, dependencies = dependencies)
   check_cran(pkgs, revdep_pkg = pkg$package, libpath = libpath,
     srcpath = srcpath, bioconductor = bioconductor, type = type,
-    threads = threads, check_dir = check_dir)
+    threads = threads, check_dir = check_dir, ...)
 
   list(check_dir = check_dir, libpath = libpath, pkg = pkg, deps = pkgs)
 }

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -5,7 +5,7 @@
 \title{Build and check a package, cleaning up automatically on success.}
 \usage{
 check(pkg = ".", document = TRUE, cleanup = TRUE, cran = TRUE,
-  check_version = FALSE, force_suggests = TRUE, args = NULL,
+  check_version = FALSE, force_suggests = FALSE, args = NULL,
   build_args = NULL, quiet = FALSE, check_dir = tempdir(),
   env_vars = NULL, ...)
 }

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -5,8 +5,9 @@
 \title{Build and check a package, cleaning up automatically on success.}
 \usage{
 check(pkg = ".", document = TRUE, cleanup = TRUE, cran = TRUE,
-  check_version = FALSE, force_suggests = FALSE, args = NULL,
-  build_args = NULL, quiet = FALSE, check_dir = tempdir(), ...)
+  check_version = FALSE, force_suggests = TRUE, args = NULL,
+  build_args = NULL, quiet = FALSE, check_dir = tempdir(),
+  env_vars = NULL, ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -36,6 +37,8 @@ line arguments to be passed to \code{R CMD check}/\code{R CMD build}/\code{R CMD
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
 
 \item{check_dir}{the directory in which the package is checked}
+
+\item{env_vars}{environment variables to set or modify during check}
 
 \item{...}{Additional arguments passed to \code{\link{build}}}
 }

--- a/man/check_cran.Rd
+++ b/man/check_cran.Rd
@@ -7,7 +7,7 @@
 check_cran(pkgs, libpath = file.path(tempdir(), "R-lib"), srcpath = libpath,
   bioconductor = FALSE, type = getOption("pkgType"),
   threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"),
-  revdep_pkg = NULL)
+  revdep_pkg = NULL, env_vars = NULL)
 }
 \arguments{
 \item{pkgs}{Vector of package names - note that unlike other \pkg{devtools}
@@ -34,6 +34,9 @@ It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
 \item{revdep_pkg}{Optional name of a package for which this check is
 checking the reverse dependencies of. This is normally passed in from
 \code{\link{revdep_check}}, and is used only for logging.}
+
+\item{env_vars}{Optional additional environment variables to set.  Values
+set here will override the defaults set by \code{\link{cran_env_vars}()}.}
 }
 \value{
 Returns (invisibly) the directory where check results are stored.

--- a/man/revdep_check.Rd
+++ b/man/revdep_check.Rd
@@ -17,7 +17,7 @@ revdep_check(pkg = ".", recursive = FALSE, ignore = NULL,
   dependencies = c("Depends", "Imports", "Suggests", "LinkingTo"),
   libpath = getOption("devtools.revdep.libpath"), srcpath = libpath,
   bioconductor = FALSE, type = getOption("pkgType"),
-  threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"))
+  threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"), ...)
 }
 \arguments{
 \item{res}{Result of \code{revdep_check}}
@@ -54,6 +54,8 @@ to the same type as \code{\link{install.packages}()}.}
 It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
 
 \item{check_dir}{Directory to store results.}
+
+\item{...}{Additional arguments passed to \code{\link{check_cran}()}}
 }
 \value{
 An invisible list of results. But you'll probably want to look

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -20,3 +20,16 @@ test_that("return messages", {
                              warning = TRUE, note = TRUE)
   expect_equal(failures, character(), info = paste(failures, collapse = "\n"))
 })
+
+test_that("setting env_vars overrides defaults", {
+  R_call <- tryCatch(
+    with_mock(
+      `devtools:::R` = function(...) stop(structure(list(...), class=c("error", "condition"))),
+      check_r_cmd(
+        "testTest",
+        cran = TRUE,
+        env_vars = list("_R_CHECK_LIMIT_CORES_" = "warn"))),
+    error = function(e) e)
+
+  expect_equal(R_call[[3]]$`_R_CHECK_LIMIT_CORES_`, "warn")
+})

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -21,7 +21,7 @@ test_that("return messages", {
   expect_equal(failures, character(), info = paste(failures, collapse = "\n"))
 })
 
-test_that("setting env_vars overrides defaults", {
+test_that("setting env_vars works as expected", {
   R_call <- tryCatch(
     with_mock(
       `R` = function(...) stop(structure(list(...), class=c("error", "condition"))),

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -24,7 +24,7 @@ test_that("return messages", {
 test_that("setting env_vars overrides defaults", {
   R_call <- tryCatch(
     with_mock(
-      `devtools:::R` = function(...) stop(structure(list(...), class=c("error", "condition"))),
+      `R` = function(...) stop(structure(list(...), class=c("error", "condition"))),
       check_r_cmd(
         "testTest",
         cran = TRUE,


### PR DESCRIPTION
This allows adding or overriding the default environment variables set
by check().

This was needed when I was doing reverse dependencies for Bioconductor packages, `cran = TRUE` sets `_R_CHECK_LIMIT_CORES_ = TRUE`, which fails the check whenever a package uses more than 2 cores in examples or vignettes.

Bioconductor however allows packages to use many cores in examples and vignettes, so I needed a way to set `_R_CHECK_LIMIT_CORES_ = warn` instead.

I added a test to check for the proper behavior, but it required a fairly hacky use of `tryCatch`, `with_mock()` and `stop()` to abort from the function prior to the normal end.  If there is a cleaner way to do this test I would be happy to make the necessary changes.