### PR TITLE
Use BiocInstaller repositories if installing a Bioconductor package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # devtools 1.9.0
 
+* Detect if `install_` commands are called on a Bioconductor package and
+  include the Bioconductor repositories if they are not already set (#895,
+  @jimhester).
+
 * Avoid importing heavy dependencies to speed up loading (#830, @krlmlr).
 
 * Remove explicit `library(testthat)` call in `test()` (#798, @krlmlr).

--- a/R/deps.R
+++ b/R/deps.R
@@ -82,6 +82,15 @@ dev_package_deps <- function(pkg = ".", dependencies = NA,
   parsed <- lapply(pkg[tolower(dependencies)], parse_deps)
   deps <- unlist(lapply(parsed, `[[`, "name"), use.names = FALSE)
 
+  if (is_bioconductor(pkg)) {
+    bioc_repos <- BiocInstaller::biocinstallRepos()
+
+    missing_repos <- setdiff(names(bioc_repos), names(repos))
+
+    if (length(missing_repos) > 0)
+      repos[missing_repos] <- bioc_repos[missing_repos]
+  }
+
   package_deps(deps, repos = repos, type = type)
 }
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -97,3 +97,7 @@ file_ext <- function (x) {
     pos <- regexpr("\\.((tar\\.)?[[:alnum:]]+)$", x)
     ifelse(pos > -1L, substring(x, pos + 1L), "")
 }
+
+is_bioconductor <- function(x) {
+  !is.null(x$biocviews)
+}


### PR DESCRIPTION
If the user specified repositories take precedence over the default
Bioconductor repositories.

This allows one to use `install_github()` with Bioconductor packages and have the dependencies work like any other package. e.g.
```r
install_github("Bioconductor-mirror/S4Vectors")
```