### PR TITLE
DevPackage Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .Rhistory
 .project
 .settings/
+inst/doc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,9 +11,9 @@ Authors@R: c(
 Description: Collection of package development tools.
 URL: http://github.com/hadley/devtools
 BugReports: http://github.com/hadley/devtools/issues
-Depends:
+Depends: 
     R (>= 3.0.2)
-Imports:
+Imports: 
     httr (>= 0.4),
     curl (>= 0.9),
     utils,
@@ -29,7 +29,7 @@ Imports:
     rversions,
     stats,
     git2r (>= 0.10.1)
-Suggests:
+Suggests: 
     testthat (>= 0.7),
     BiocInstaller,
     Rcpp (>= 0.10.0),
@@ -39,3 +39,4 @@ Suggests:
     lintr (>= 0.2.1),
     bitops
 License: GPL (>= 2)
+VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   include the Bioconductor repositories if they are not already set (#895,
   @jimhester).
 
+* `install()` can now install dependencies from remote repositories by
+  specifying them as `Remotes` in the `DESCRIPTION` file (#902, @jimhester).
+
 * Avoid importing heavy dependencies to speed up loading (#830, @krlmlr).
 
 * Remove explicit `library(testthat)` call in `test()` (#798, @krlmlr).

--- a/R/deps.R
+++ b/R/deps.R
@@ -137,7 +137,7 @@ dev_remote_type <- function(remotes = "") {
     return()
   }
 
-  dev_packages <- trimws(unlist(strsplit(remotes, ",[[:space:]]*")))
+  dev_packages <- trim_ws(unlist(strsplit(remotes, ",[[:space:]]*")))
 
   pieces <- strsplit(dev_packages, "|", fixed = TRUE)
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -137,7 +137,7 @@ dev_remote_type <- function(remotes) {
 
   pieces <- strsplit(dev_packages, "|", fixed = TRUE)
 
-  repositories <- mapply(`[`, pieces, lengths(pieces), SIMPLIFY = FALSE)
+  repositories <- Map(`[`, pieces, lengths(pieces))
 
   types <- lapply(pieces, function(x) if (length(x) == 1) "github" else tolower(x[[1]]))
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -120,11 +120,11 @@ compare_versions <- function(a, b) {
 install_dev_remotes <- function(pkg, ...) {
   pkg <- as.package(pkg)
 
-  if (is.null(pkg$remotes)) {
+  if (is.null(pkg[["remotes"]])) {
     return()
   }
 
-  types <- lapply(pkg$remotes, dev_remote_type)
+  types <- lapply(pkg[["remotes"]], dev_remote_type)
 
   lapply(types, function(type) type$fun(type$repository, ...))
 }

--- a/R/release.r
+++ b/R/release.r
@@ -57,6 +57,11 @@ release <- function(pkg = ".", check = TRUE) {
       warning("Git not synched with remote.", immediate. = TRUE, call. = FALSE)
   }
 
+  if (has_dev_remotes(pkg)) {
+    warning("Package ", pkg$package, "has a 'Remotes:' entry.  This should be
+      removed before CRAN submission.", immediate. = TRUE, call. = FALSE)
+  }
+
   if (check) {
     check(pkg, cran = TRUE, check_version = TRUE, manual = TRUE)
     release_checks(pkg)

--- a/R/utils.r
+++ b/R/utils.r
@@ -101,3 +101,7 @@ file_ext <- function (x) {
 is_bioconductor <- function(x) {
   !is.null(x$biocviews)
 }
+
+trim_ws <- function(x) {
+  gsub("^[[:space:]]+|[[:space:]]+$", "", x)
+}

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -21,16 +21,16 @@ test_that("dev_remote_type works with implicit types", {
 test_that("dev_remote_type errors", {
   expect_equal(dev_remote_type(""), NULL)
 
-  expect_error(dev_remote_type("git|testthat|blah"),
-    "Malformed remote specification 'git|testthat|blah'")
-  expect_error(dev_remote_type("hadley|testthat"),
-    "Function 'install_hadley' does not exist")
-  expect_error(dev_remote_type("SVN2|testthat"),
-    "Function 'install_svn2' does not exist")
+  expect_error(dev_remote_type("git::testthat::blah"),
+    "Malformed remote specification 'git::testthat::blah'")
+  expect_error(dev_remote_type("hadley::testthat"),
+    "Malformed remote specification 'hadley::testthat'")
+  expect_error(dev_remote_type("SVN2::testthat"),
+    "Malformed remote specification 'SVN2::testthat'")
 })
 
 test_that("dev_remote_type works with explicit types", {
-  expect_equal(dev_remote_type("github|hadley/testthat"),
+  expect_equal(dev_remote_type("github::hadley/testthat"),
     list(list(repository = "hadley/testthat", type = "github", fun = install_github)))
 
   simple_github <-
@@ -39,11 +39,11 @@ test_that("dev_remote_type works with explicit types", {
       list(repository = "klutometis/roxygen", type = "github", fun = install_github)
     )
 
-  expect_equal(dev_remote_type("github|hadley/testthat,klutometis/roxygen"), simple_github)
-  expect_equal(dev_remote_type("hadley/testthat,github|klutometis/roxygen"), simple_github)
-  expect_equal(dev_remote_type("github|hadley/testthat,github|klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("github::hadley/testthat,klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("hadley/testthat,github::klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("github::hadley/testthat,github::klutometis/roxygen"), simple_github)
 
-  expect_equal(dev_remote_type("svn|https://github.com/hadley/testthat,\n  git|https://github.com/klutometis/roxygen.git"),
+  expect_equal(dev_remote_type("svn::https://github.com/hadley/testthat,\n  git::https://github.com/klutometis/roxygen.git"),
     list(
       list(repository = "https://github.com/hadley/testthat", type = "svn", fun = install_svn),
       list(repository = "https://github.com/klutometis/roxygen.git", type = "git", fun = install_git)

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -1,0 +1,40 @@
+context("install_dev_remotes")
+test_that("install_dev_remotes returns if no remotes specified", {
+  expect_equal(install_dev_remotes("testTest/"), NULL)
+})
+
+test_that("dev_remote_type works with implicit types", {
+  expect_equal(dev_remote_type("hadley/testthat"),
+    list(list(repository = "hadley/testthat", type = "github", fun = install_github)))
+
+  simple_github <-
+    list(
+      list(repository = "hadley/testthat", type = "github", fun = install_github),
+      list(repository = "klutometis/roxygen", type = "github", fun = install_github)
+    )
+
+  expect_equal(dev_remote_type("hadley/testthat,klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("hadley/testthat,\n  klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("hadley/testthat,\n\tklutometis/roxygen"), simple_github)
+})
+
+test_that("dev_remote_type works with explicit types", {
+  expect_equal(dev_remote_type("github|hadley/testthat"),
+    list(list(repository = "hadley/testthat", type = "github", fun = install_github)))
+
+  simple_github <-
+    list(
+      list(repository = "hadley/testthat", type = "github", fun = install_github),
+      list(repository = "klutometis/roxygen", type = "github", fun = install_github)
+    )
+
+  expect_equal(dev_remote_type("github|hadley/testthat,klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("hadley/testthat,github|klutometis/roxygen"), simple_github)
+  expect_equal(dev_remote_type("github|hadley/testthat,github|klutometis/roxygen"), simple_github)
+
+  expect_equal(dev_remote_type("svn|https://github.com/hadley/testthat,\n  git|https://github.com/klutometis/roxygen.git"),
+    list(
+      list(repository = "https://github.com/hadley/testthat", type = "svn", fun = install_svn),
+      list(repository = "https://github.com/klutometis/roxygen.git", type = "git", fun = install_git)
+    ))
+})

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -18,6 +18,17 @@ test_that("dev_remote_type works with implicit types", {
   expect_equal(dev_remote_type("hadley/testthat,\n\tklutometis/roxygen"), simple_github)
 })
 
+test_that("dev_remote_type errors", {
+  expect_equal(dev_remote_type(""), NULL)
+
+  expect_error(dev_remote_type("git|testthat|blah"),
+    "Malformed remote specification 'git|testthat|blah'")
+  expect_error(dev_remote_type("hadley|testthat"),
+    "Function 'install_hadley' does not exist")
+  expect_error(dev_remote_type("SVN2|testthat"),
+    "Function 'install_svn2' does not exist")
+})
+
 test_that("dev_remote_type works with explicit types", {
   expect_equal(dev_remote_type("github|hadley/testthat"),
     list(list(repository = "hadley/testthat", type = "github", fun = install_github)))

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -1,0 +1,86 @@
+---
+title: "Devtools Remote Dependencies"
+author: "Jim Hester"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Devtools dependency Resolution}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+Devtools version 1.9 supports package dependency installation for packages not
+yet in a standard package repository such as [CRAN](http://cran.r-project.org)
+or [Bioconductor](http://bioconductor.org).
+
+You can mark any regular dependency defined in the `Depends`, `Imports`,
+`Suggests` or `Enhances` fields as being installed from a remote location by
+adding the remote location to `Remotes` in your `DESCRIPTION` file.  This will
+cause devtools to download and install them prior to installing your package.
+
+The remote dependencies specified in `Remotes` should be described in the following form.
+
+```
+Remotes: [type|]<Repository>, [type2|]<Repository2>
+```
+Where the `type` is an optional parameter.  If the type is missing the default is
+to install from GitHub. Additional remote dependencies should be separated by
+commas, just like normal dependencies elsewhere in the `DESCRIPTION` file.
+
+All of the currently supported install sources are available, see the 'See
+Also' section in `?install` for a complete list.
+
+Here are some examples for each of the backends.
+
+### GitHub ###
+```
+Remotes: hadley/testthat
+```
+You can also specify a specific hash, tag or pull request if you want a
+particular commit.  Otherwise the latest commit on the master branch is used.
+
+```
+Remotes: hadley/httr@v0.4,
+  klutometis/roxygen#142,
+  hadley/testthat@c67018fa4970
+```
+A type of 'github' can be specified, but is not required
+```
+Remotes: github|hadley/ggplot2
+```
+
+### Git ###
+Specify a git repository using `install_git()`.
+```
+Remotes: git|https://github.com/hadley/ggplot2.git
+```
+
+### Bitbucket ###
+Specify a Bitbucket repository using `install_bitbucket()`.
+```
+Remotes: bitbucket|sulab/mygene.r@default, dannavarro/lsr-package
+```
+
+### SVN ###
+Specify a Subversion repository using `install_svn()`.
+```
+Remotes: svn|https://github.com/hadley/stringr
+```
+
+### URL ###
+Specify a URL repository using `install_url()`.
+```
+Remotes: url|https://github.com/hadley/stringr/archive/master.zip
+```
+
+### Local ###
+Specify a local repository using `install_local()`.
+```
+Remotes: local|/pkgs/testthat
+```
+
+### Gitorious ###
+Specify a Gitorious repository using `install_gitorious()`.
+```
+Remotes: gitorious|r-mpc-package/r-mpc-package
+```

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -1,13 +1,15 @@
 ---
-title: "Devtools Remote Dependencies"
+title: "Devtools dependencies"
 author: "Jim Hester"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Devtools dependency Resolution}
+  %\VignetteIndexEntry{Devtools dependencies}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
+
+# Remote versions #
 
 Devtools version 1.9 supports package dependency installation for packages not
 yet in a standard package repository such as [CRAN](http://cran.r-project.org)
@@ -32,7 +34,7 @@ Also' section in `?install` for a complete list.
 
 Here are some examples for each of the backends.
 
-### GitHub ###
+- GitHub
 ```
 Remotes: hadley/testthat
 ```
@@ -49,37 +51,37 @@ A type of 'github' can be specified, but is not required
 Remotes: github|hadley/ggplot2
 ```
 
-### Git ###
+- Git
 Specify a git repository using `install_git()`.
 ```
 Remotes: git|https://github.com/hadley/ggplot2.git
 ```
 
-### Bitbucket ###
+- Bitbucket
 Specify a Bitbucket repository using `install_bitbucket()`.
 ```
 Remotes: bitbucket|sulab/mygene.r@default, dannavarro/lsr-package
 ```
 
-### SVN ###
+- SVN
 Specify a Subversion repository using `install_svn()`.
 ```
 Remotes: svn|https://github.com/hadley/stringr
 ```
 
-### URL ###
+- URL
 Specify a URL repository using `install_url()`.
 ```
 Remotes: url|https://github.com/hadley/stringr/archive/master.zip
 ```
 
-### Local ###
+- Local
 Specify a local repository using `install_local()`.
 ```
 Remotes: local|/pkgs/testthat
 ```
 
-### Gitorious ###
+- Gitorious
 Specify a Gitorious repository using `install_gitorious()`.
 ```
 Remotes: gitorious|r-mpc-package/r-mpc-package

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -23,7 +23,7 @@ cause devtools to download and install them prior to installing your package.
 The remote dependencies specified in `Remotes` should be described in the following form.
 
 ```
-Remotes: [type|]<Repository>, [type2|]<Repository2>
+Remotes: [type::]<Repository>, [type2::]<Repository2>
 ```
 Where the `type` is an optional parameter.  If the type is missing the default is
 to install from GitHub. Additional remote dependencies should be separated by
@@ -48,41 +48,41 @@ Remotes: hadley/httr@v0.4,
 ```
 A type of 'github' can be specified, but is not required
 ```
-Remotes: github|hadley/ggplot2
+Remotes: github::hadley/ggplot2
 ```
 
 - Git
 Specify a git repository using `install_git()`.
 ```
-Remotes: git|https://github.com/hadley/ggplot2.git
+Remotes: git::https://github.com/hadley/ggplot2.git
 ```
 
 - Bitbucket
 Specify a Bitbucket repository using `install_bitbucket()`.
 ```
-Remotes: bitbucket|sulab/mygene.r@default, dannavarro/lsr-package
+Remotes: bitbucket::sulab/mygene.r@default, dannavarro/lsr-package
 ```
 
 - SVN
 Specify a Subversion repository using `install_svn()`.
 ```
-Remotes: svn|https://github.com/hadley/stringr
+Remotes: svn::https://github.com/hadley/stringr
 ```
 
 - URL
 Specify a URL repository using `install_url()`.
 ```
-Remotes: url|https://github.com/hadley/stringr/archive/master.zip
+Remotes: url::https://github.com/hadley/stringr/archive/master.zip
 ```
 
 - Local
 Specify a local repository using `install_local()`.
 ```
-Remotes: local|/pkgs/testthat
+Remotes: local::/pkgs/testthat
 ```
 
 - Gitorious
 Specify a Gitorious repository using `install_gitorious()`.
 ```
-Remotes: gitorious|r-mpc-package/r-mpc-package
+Remotes: gitorious::r-mpc-package/r-mpc-package
 ```


### PR DESCRIPTION
This allows package authors to specify DevPackage in their DESCRIPTION,
which devtools will use to install development versions of the
dependencies prior to looking for them in normal repositories.  The
format is 'type|user/repo', where type is optional (default github)
defining the install_type to use, e.g. (git, gitorious, svn, ect.).

An example description would be (for the ggplot2 book for instance)
```
Package: ggbook2
Title: ggbook2 is not really an R package, but this is here to list the dependencies for building the ggplot2 book.
Version: 0.1
Authors@R: person("First", "Last", email = "first.last@example.com",
                  role = c("aut", "cre"))
Depends: R (>= 3.1.0)
URL: https://github.com/hadley/ggplot2-book
Imports:
  lubridate,
  rvest,
  magrittr,
  dplyr,
  plyr,
  tidyr,
  xtable,
  nlme,
  effects,
  broom,
  hexbin,
  maps,
  Hmisc,
  devtools,
  readr,
  rmarkdown,
  Lahman,
  ggmap,
  directlabels,
  wesanderson,
  babynames
DevPackage:
  hadley/bookdown,
  hadley/scales, 
  hadley/ggplot2,
  hadley/ggplot2movies,
  hadley/tidyr,
  hadley/directlabels, 
  jrnold/ggthemes
SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc
```
This would allow people to install it with simply
```r
devtools::install_github("hadley/ggplot2-book")
```

This implementation seems to work fine as-is, but I had a few questions as far as the API

1. Is this useful (I think it is)!
2. Is `DevPackage` a good name for this or should we use something else?
3. is `|` a good delimiter for the type?  I picked it because it should not appear in URLs or user/repository names.  Using `/` or `:` seem like they would require more complicated logic to parse properly in all cases.
4. Where is the best place to document/popularize this feature?  The functions to implement are all non-exported.
5. What is the best way to test this, just mock the install functions and verify we are passing them the correct parameters?