### PR TITLE
Fix with_lib tests on Windows

### DIFF
--- a/tests/testthat/test-with.r
+++ b/tests/testthat/test-with.r
@@ -47,7 +47,10 @@ test_that("with_lib works and resets library", {
   new_lib <- "."
   with_lib(
     new_lib,
-    expect_true(normalizePath(new_lib) %in% .libPaths())
+    {
+      expect_equal(normalizePath(new_lib), normalizePath(.libPaths()[[1L]]))
+      expect_equal(length(.libPaths()), length(lib) + 1L)
+    }
   )
   expect_equal(lib, .libPaths())
 })
@@ -57,7 +60,9 @@ test_that("with_libpaths works and resets library", {
   new_lib <- "."
   with_libpaths(
     new_lib,
-    expect_true(normalizePath(new_lib) %in% .libPaths())
+    {
+      expect_equal(normalizePath(new_lib), normalizePath(.libPaths()[[1L]]))
+    }
   )
   expect_equal(lib, .libPaths())
 })


### PR DESCRIPTION
Something was weird with the normalization of the paths, perhaps some 8.3 problem. Now the tests also normalize the return value of .libPaths(), this seems to fix the issue.

Works according to WinBuilder:
http://win-builder.r-project.org/4NAgZD9sPrem.

~~~This should now work also on Windows, if not please ping me again.~~~