### PR TITLE
bugfix when calling install_dev_remotes

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -124,7 +124,7 @@ install_dev_remotes <- function(pkg, ...) {
     return()
   }
 
-  types <- lapply(pkg[["remotes"]], dev_remote_type)
+  types <- dev_remote_type(pkg[["remotes"]])
 
   lapply(types, function(type) type$fun(type$repository, ...))
 }


### PR DESCRIPTION
The last refactoring of `install_dev_remotes` had a bug which made it non-functional.

This should fix things so it actually works, sorry I missed this earlier!