### PR TITLE
convert errors to warnings when processing NAMESPACE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,9 @@
 * `remove_s4classes()` performs a topological sort of the classes
   (#848, #849, @famuvie).
 
+* `load_all()` warns (instead of failing) if importing symbols, methods, or classes
+   from `NAMESPACE` fails (@krlmlr, #921).
+
 # devtools 1.8.0
  
 ## Helpers

--- a/R/imports-env.r
+++ b/R/imports-env.r
@@ -74,10 +74,13 @@ process_imports <- function(pkg = ".") {
 
   ## process imports
   for (i in nsInfo$imports) {
-    if (is.character(i))
-      namespaceImport(ns, loadNamespace(i))
-    else
-      namespaceImportFrom(ns, loadNamespace(i[[1L]]), i[[2L]])
+    tryCatch(
+      if (is.character(i))
+        namespaceImport(ns, loadNamespace(i))
+      else
+        namespaceImportFrom(ns, loadNamespace(i[[1L]]), i[[2L]]),
+      error = warning
+    )
   }
   for(imp in nsInfo$importClasses)
     namespaceImportClasses(ns, loadNamespace(imp[[1L]]), imp[[2L]])

--- a/R/imports-env.r
+++ b/R/imports-env.r
@@ -82,8 +82,16 @@ process_imports <- function(pkg = ".") {
       error = warning
     )
   }
-  for(imp in nsInfo$importClasses)
-    namespaceImportClasses(ns, loadNamespace(imp[[1L]]), imp[[2L]])
-  for(imp in nsInfo$importMethods)
-    namespaceImportMethods(ns, loadNamespace(imp[[1L]]), imp[[2L]])
+  for(imp in nsInfo$importClasses) {
+    tryCatch(
+      namespaceImportClasses(ns, loadNamespace(imp[[1L]]), imp[[2L]]),
+      error = warning
+    )
+  }
+  for(imp in nsInfo$importMethods) {
+    tryCatch(
+      namespaceImportMethods(ns, loadNamespace(imp[[1L]]), imp[[2L]]),
+      error = warning
+    )
+  }
 }


### PR DESCRIPTION
in `process_imports`

Reason: Otherwise, `devtools::document` cannot fix a `NAMESPACE` file that became invalid due to changes in external packages

(I'm not sure if this worked before.)