### PR TITLE
Allow for ssh keys with passphrase

### DIFF
--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -37,17 +37,25 @@ automatically. \code{\link{use_github_links}} is called to populate the
 
   The argument \code{protocol} reflects how you wish to authenticate with
   GitHub for this repo in the long run. For either \code{protocol}, a remote
-  named "origin" is created, an initial push is made using \code{auth_token}
-  for authentication, and a remote tracking branch is set. The URL of the
+  named "origin" is created, an initial push is made using the specified
+  \code{protocol}, and a remote tracking branch is set. The URL of the
   "origin" remote has the form \code{git@github.com:<USERNAME>/<REPO>.git}
   (\code{protocol = "ssh"}, the default) or
   \code{https://github.com/<USERNAME>/<REPO>.git} (\code{protocol =
-  "https"}).
+  "https"}). For \code{protocol = "ssh"}, it is assumed that public and
+  private keys are in the default locations, \code{~/.ssh/id_rsa.pub} and
+  \code{~/.ssh/id_rsa}, respectively, and that \code{ssh-agent} is configured
+  to manage any associated passphrase.
 }
 \examples{
 \dontrun{
+## to use default ssh protocol
 create("testpkg")
-use_github(pkg = "testpkg", private = TRUE)
+use_github(pkg = "testpkg")
+
+## or use https
+create("testpkg2")
+use_github(pkg = "testpkg2", protocol = "https")
 }
 }
 \seealso{


### PR DESCRIPTION
Solves difficulties setting remote tracking branch when protocol is ssh and the ssh keys have a passphrase. See https://github.com/hadley/devtools/issues/642.