### PR TITLE
Explicitly request consent for sending e-mail to maintainer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 
 * `build_win()` now uses `curl` instead of `RCurl` for ftp upload.
 
+* `build_win()` asks for consent to receive e-mail at maintainer address
+  in interactive mode (#800, @krlmlr).
+
 * `check()` now uses a better strategy when `cran = TRUE`. Instead of 
   attempting to simulate `--as-cran` behaviour by turning on certain env vars,
   it now uses `--as-cran` and turns off problematic checks with env vars (#866).

--- a/R/build.r
+++ b/R/build.r
@@ -99,6 +99,9 @@ build_win <- function(pkg = ".", version = c("R-release", "R-devel"),
     message("Building windows version of ", pkg$package,
             " for ", paste(version, collapse=", "),
             " with win-builder.r-project.org.\n")
+    if (interactive() && yesno("E-mail will be delivered to ", maintainer(pkg)$email, ".")) {
+      return(invisible())
+    }
   }
 
   built_path <- build(pkg, tempdir(), args = args, quiet = quiet)


### PR DESCRIPTION
`build_win()`, only in interactive mode. A cheap solution to #800.