### PR TITLE
Degrade gracefully if summary cannot be retrieved for one of the checked packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* Checking reverse dependencies is now more tolerant of errors when
+  retrieving the summary for a checked package (#929, @krlmlr).
+
 * 'Check failed:' now includes the package name for when Ncpus>1 so you
    know which package has failed and can start looking at the output without
    needing to wait for all packages to finish (@mattdowle).

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -48,7 +48,7 @@ revdep_check_summary <- function(res) {
   pkg_df <- package_info(pkgs, libpath = res$libpath)
 
   checks <- check_dirs(res$check_dir)
-  summaries <- vapply(checks, check_summary_package, character(1))
+  summaries <- vapply(checks, try_check_summary_package, character(1))
 
   paste0(
     "# Setup\n\n",
@@ -62,6 +62,14 @@ revdep_check_summary <- function(res) {
     paste0(length(checks), " checked out of ", length(res$deps), " dependencies \n\n"),
     paste0(summaries, collapse = "\n")
   )
+}
+
+try_check_summary_package <- function(path) {
+  res <- try(check_summary_package(path), silent = TRUE)
+  if (inherits(res, "try-error")) {
+    res <- as.character(res)
+  }
+  res
 }
 
 check_summary_package <- function(path) {

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -17,8 +17,10 @@ revdep_check_save_logs <- function(res, log_dir = "revdep") {
 
     file.copy(file.path(path, logs), file.path(out, logs))
 
-    desc <- check_description(path)
-    write_dcf(file.path(out, "DESCRIPTION"), desc[c("Package", "Version", "Maintainer")])
+    try({
+      desc <- check_description(path)
+      write_dcf(file.path(out, "DESCRIPTION"), desc[c("Package", "Version", "Maintainer")])
+    })
   }
 
   pkgs <- check_dirs(res$check_dir)

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -17,9 +17,11 @@ revdep_check_save_logs <- function(res, log_dir = "revdep") {
 
     file.copy(file.path(path, logs), file.path(out, logs))
 
-    try({
+    tryCatch({
       desc <- check_description(path)
       write_dcf(file.path(out, "DESCRIPTION"), desc[c("Package", "Version", "Maintainer")])
+    }, error = function(e) {
+      message("Error checking DESCRIPTION for ", pkg, ": ", e$message)
     })
   }
 
@@ -67,11 +69,10 @@ revdep_check_summary <- function(res) {
 }
 
 try_check_summary_package <- function(path) {
-  res <- try(check_summary_package(path), silent = TRUE)
-  if (inherits(res, "try-error")) {
-    res <- as.character(res)
-  }
-  res
+  res <- tryCatch(
+    check_summary_package(path),
+    error = function(e) e$message
+  )
 }
 
 check_summary_package <- function(path) {


### PR DESCRIPTION
- example: if the DESCRIPTION file in one of the checked packages is missing