### PR TITLE
Optionally recode non-ASCII DESCRIPTION in read_dcf

### DIFF
--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -109,7 +109,7 @@ check_dirs <- function(path) {
 
 check_description <- function(path) {
   pkgname <- gsub("\\.Rcheck$", "", basename(path))
-  read_dcf(file.path(path, "00_pkg_src", pkgname, "DESCRIPTION"))
+  read_dcf(file.path(path, "00_pkg_src", pkgname, "DESCRIPTION"), recode = TRUE)
 }
 
 check_time <- function(path) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -46,8 +46,14 @@ is_installed <- function(pkg, version = 0) {
 }
 
 read_dcf <- function(path) {
-  fields <- colnames(read.dcf(path))
-  as.list(read.dcf(path, keep.white = fields)[1, ])
+  dcf <- read.dcf(path)
+  fields <- colnames(dcf)
+  if ("Encoding" %in% fields) {
+    encoding <- dcf[1L, "Encoding"]
+  } else {
+    encoding <- "UTF-8"
+  }
+  as.list(iconv(from = encoding, read.dcf(path, keep.white = fields)[1, ]))
 }
 
 write_dcf <- function(path, desc) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -59,7 +59,7 @@ read_dcf <- function(path, recode = FALSE) {
   dcf <- read.dcf(path, all = FALSE, keep.white = fields)[1, ]
   if (recode && encoding != "ASCII") {
     dcf <- iconv(from = encoding, dcf)
-    dcf$Encoding <- "UTF-8"
+    dcf[["Encoding"]] <- "UTF-8"
   }
   as.list(dcf)
 }

--- a/R/utils.r
+++ b/R/utils.r
@@ -45,15 +45,23 @@ is_installed <- function(pkg, version = 0) {
   system.file(package = pkg) != "" && packageVersion(pkg) > version
 }
 
-read_dcf <- function(path) {
-  dcf <- read.dcf(path)
+read_dcf <- function(path, recode = FALSE) {
+  # First pass: Determine field names and encoding
+  dcf <- read.dcf(path, all = FALSE)
   fields <- colnames(dcf)
   if ("Encoding" %in% fields) {
     encoding <- dcf[1L, "Encoding"]
   } else {
-    encoding <- "UTF-8"
+    encoding <- "ASCII"
   }
-  as.list(iconv(from = encoding, read.dcf(path, keep.white = fields)[1, ]))
+
+  # Second pass: Read and recode
+  dcf <- read.dcf(path, all = FALSE, keep.white = fields)[1, ]
+  if (recode && encoding != "ASCII") {
+    dcf <- iconv(from = encoding, dcf)
+    dcf$Encoding <- "UTF-8"
+  }
+  as.list(dcf)
 }
 
 write_dcf <- function(path, desc) {


### PR DESCRIPTION
- recode DESCRIPTION files for revdep check, to ensure their contents can be written when creating the summary
- also, use all = FALSE for read.dcf() to always return a matrix, even for malformed DESCRIPTION files