### PR TITLE
Use get directly instead of match.fun

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* Bugfix for `Remotes: ` feature that prevented it from working if devtools was
+  not attached as is done in travis-r (#936, @jimhester).
+
 # devtools 1.9.1
 
 * Avoid importing heavy dependencies to speed up loading (#830, @krlmlr).

--- a/R/deps.R
+++ b/R/deps.R
@@ -152,7 +152,9 @@ dev_remote_type <- function(remotes = "") {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
-    tryCatch(fun <- get(paste0("install_", tolower(type)), envir=asNamespace("devtools")),
+    tryCatch(fun <- get(x = paste0("install_", tolower(type)),
+                        envir = asNamespace("devtools"),
+                        mode = "function"),
       error = function(e) {
         stop("Malformed remote specification '", x, "'", call. = FALSE)
       })

--- a/R/deps.R
+++ b/R/deps.R
@@ -155,7 +155,8 @@ dev_remote_type <- function(remotes = "") {
     tryCatch(
       fun <- get(x = paste0("install_", tolower(type)),
         envir = asNamespace("devtools"),
-        mode = "function"),
+        mode = "function",
+        inherits = FALSE),
       error = function(e) {
         stop("Malformed remote specification '", x, "'", call. = FALSE)
       })

--- a/R/deps.R
+++ b/R/deps.R
@@ -152,7 +152,7 @@ dev_remote_type <- function(remotes = "") {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
-    tryCatch(fun <- match.fun(paste0("install_", tolower(type))),
+    tryCatch(fun <- get(paste0("install_", tolower(type)), envir=asNamespace("devtools")),
       error = function(e) {
         stop("Malformed remote specification '", x, "'", call. = FALSE)
       })

--- a/R/deps.R
+++ b/R/deps.R
@@ -152,9 +152,10 @@ dev_remote_type <- function(remotes = "") {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
-    tryCatch(fun <- get(x = paste0("install_", tolower(type)),
-                        envir = asNamespace("devtools"),
-                        mode = "function"),
+    tryCatch(
+      fun <- get(x = paste0("install_", tolower(type)),
+        envir = asNamespace("devtools"),
+        mode = "function"),
       error = function(e) {
         stop("Malformed remote specification '", x, "'", call. = FALSE)
       })


### PR DESCRIPTION
The previous implementation used `match.fun()`, which has the undesirable effect that the function cannot be found if the devtools namespace is not attached.

So `devtools::install_deps()` would fail, which is what was happening on travis (https://travis-ci.org/hadley/devtools/builds/81765159#L2108-L2110) when I tried to use `Remotes:`

This fix uses `get()` directly in the `devtools` namespace, so works regardless if devtools is attached.