### PR TITLE
Use the proper Bioconductor URL for both release and devel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* Use proper repository when checking reverse dependencies when
+  `BiocInstaller::useDevel(TRUE)` (#937, @jimhester).
+
 * Fix longstanding lazy load database corruption issues when reloading packages
   which define S3 methods on generics from base or other packages (#1001, @jimhester).
 

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -147,13 +147,13 @@ cran_packages <- memoise::memoise(function() {
   cp
 })
 
-bioc_packages <- memoise::memoise(function() {
-  views <- paste(BiocInstaller::biocinstallRepos()[["BioCsoft"]], "VIEWS", sep = "/")
-  con <- url(views)
-  on.exit(close(con))
-  bioc <- read.dcf(con)
-  rownames(bioc) <- bioc[, 1]
-  bioc
+bioc_packages <- memoise::memoise(
+  function(views = paste(BiocInstaller::biocinstallRepos()[["BioCsoft"]], "VIEWS", sep = "/")) {
+    con <- url(views)
+    on.exit(close(con))
+    bioc <- read.dcf(con)
+    rownames(bioc) <- bioc[, 1]
+    bioc
 })
 
 packages <- function() {
@@ -162,4 +162,3 @@ packages <- function() {
   cols <- intersect(colnames(cran), colnames(bioc))
   rbind(cran[, cols], bioc[, cols])
 }
-

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -148,7 +148,8 @@ cran_packages <- memoise::memoise(function() {
 })
 
 bioc_packages <- memoise::memoise(function() {
-  con <- url("http://bioconductor.org/packages/release/bioc/VIEWS")
+  views <- paste(BiocInstaller::biocinstallRepos()[["BioCsoft"]], "VIEWS", sep = "/")
+  con <- url(views)
   on.exit(close(con))
   bioc <- read.dcf(con)
   rownames(bioc) <- bioc[, 1]


### PR DESCRIPTION
Depending on if the user has ran BiocInstaller::useDevel() the
repository URL differs. The previous behavior was hard-coded to look only
at Bioconductor package in the last release. Making URL a parameter
ensures that if the user changes from looking at devel to release in the
same session the previous cached result will not be used.