### PR TITLE
Supply the 'package' argument for .Deprecated()

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -175,7 +175,7 @@ use_travis <- function(pkg = ".") {
 #' Add coveralls to basic travis template to a package.
 #' @export
 use_coveralls <- function(pkg = ".") {
-  .Deprecated("use_coverage(type = \"coveralls\")")
+  .Deprecated("use_coverage(type = \"coveralls\")", package = "devtools")
   use_coverage(pkg, type = "coveralls")
 }
 


### PR DESCRIPTION
This modifies the deprecation warning to point users to `devtools-deprecated` for help.