### PR TITLE
Move curl dependency to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Depends:
     R (>= 3.0.2)
 Imports:
     httr (>= 0.4),
-    curl (>= 0.9),
     utils,
     tools,
     methods,
@@ -30,6 +29,7 @@ Imports:
     stats,
     git2r (>= 0.11.0)
 Suggests:
+    curl (>= 0.9),
     testthat (>= 0.7),
     BiocInstaller,
     Rcpp (>= 0.10.0),

--- a/R/upload-ftp.r
+++ b/R/upload-ftp.r
@@ -1,4 +1,8 @@
 upload_ftp <- function(file, url, verbose = FALSE){
+  if (packageVersion("curl") < "0.9") {
+    stop("package 'curl' must be >= 0.9")
+  }
+
   stopifnot(file.exists(file))
   stopifnot(is.character(url))
   con <- file(file, open = "rb")


### PR DESCRIPTION
It is only used in 1 function, (upload_ftp()) which is only used in
build_win() so not needed most of the time.