### PR TITLE
Move more dependencies to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,12 +21,9 @@ Imports:
     methods,
     memoise,
     whisker,
-    evaluate,
     digest,
     rstudioapi (>= 0.2.0),
     jsonlite,
-    roxygen2 (>= 4.1.1.9001),
-    rversions,
     stats,
     git2r (>= 0.11.0),
     withr
@@ -38,7 +35,10 @@ Suggests:
     rmarkdown,
     knitr,
     lintr (>= 0.2.1),
-    bitops
+    bitops,
+    roxygen2 (>= 4.1.1.9001),
+    evaluate,
+    rversions
 License: GPL (>= 2)
 VignetteBuilder: knitr
 RoxygenNote: 5.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,4 +41,4 @@ Suggests:
     rversions
 License: GPL (>= 2)
 VignetteBuilder: knitr
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Depends:
     R (>= 3.0.2)
 Imports:
     httr (>= 0.4),
-    curl (>= 0.9),
     utils,
     tools,
     methods,
@@ -28,6 +27,7 @@ Imports:
     git2r (>= 0.11.0),
     withr
 Suggests:
+    curl (>= 0.9),
     testthat (>= 0.7),
     BiocInstaller,
     Rcpp (>= 0.10.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
   which define S3 methods on generics from base or other packages (#1001, @jimhester).
 
 * `document()` now only runs `update_collate()` once.
-* Move `evaluate`, `roxygen2` and `rversions` to `Suggests:` to lighten the dependency
+* Move `curl`, `evaluate`, `roxygen2` and `rversions` to `Suggests:` to lighten the dependency
   load of devtools. If a user runs a function using these packages and
   they are not installed the user is prompted to install them (#962, @jimhester).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
   which define S3 methods on generics from base or other packages (#1001, @jimhester).
 
 * `document()` now only runs `update_collate()` once.
+* Move `evaluate`, `roxygen2` and `rversions` to `Suggests:` to lighten the dependency
+  load of devtools. If a user runs a function using these packages and
+  they are not installed the user is prompted to install them (#962, @jimhester).
 
 * Bugfix for `Remotes: ` feature that prevented it from working if devtools was
   not attached as is done in travis-r (#936, @jimhester).

--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -53,6 +53,7 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
     rule("Installing dependencies") # --------------------------------------------
     repos <- c(CRAN = "http://cran.rstudio.com/")
     if (bioconductor) {
+      check_suggested("BiocInstaller")
       repos <- c(repos, BiocInstaller::biocinstallRepos())
     }
     available_src <- available_packages(repos, "source")

--- a/R/deps.R
+++ b/R/deps.R
@@ -23,7 +23,7 @@
 #'   installation.
 #'
 #' @param object A \code{package_deps} object.
-#' @param ... Additional arguments passed to \code{\link{install.packages}}.
+#' @param ... Additional arguments passed to \code{install_packages}.
 #'
 #' @return
 #'

--- a/R/deps.R
+++ b/R/deps.R
@@ -100,6 +100,7 @@ dev_package_deps <- function(pkg = ".", dependencies = NA,
   deps <- unlist(lapply(parsed, `[[`, "name"), use.names = FALSE)
 
   if (is_bioconductor(pkg)) {
+    check_suggested("BiocInstaller")
     bioc_repos <- BiocInstaller::biocinstallRepos()
 
     missing_repos <- setdiff(names(bioc_repos), names(repos))

--- a/R/doctor.R
+++ b/R/doctor.R
@@ -10,6 +10,7 @@ NULL
 rstudio_release <- memoise::memoise(.rstudio_release)
 
 .r_release <- function() {
+  check_suggested("rversions")
   R_system_version(rversions::r_release()$version)
 }
 

--- a/R/document.r
+++ b/R/document.r
@@ -12,7 +12,7 @@
 #'   \code{browseVignettes("roxygen2")}
 #' @export
 document <- function(pkg = ".", clean = NULL, roclets = NULL, reload = TRUE) {
-  check_suggested("roxygen2", "4.1.0")
+  check_suggested("roxygen2")
   if (!missing(clean)) {
     warning("`clean` is deprecated: roxygen2 now automatically cleans up",
       call. = FALSE)

--- a/R/document.r
+++ b/R/document.r
@@ -12,6 +12,7 @@
 #'   \code{browseVignettes("roxygen2")}
 #' @export
 document <- function(pkg = ".", clean = NULL, roclets = NULL, reload = TRUE) {
+  check_suggested("roxygen2", "4.1.0")
   if (!missing(clean)) {
     warning("`clean` is deprecated: roxygen2 now automatically cleans up",
       call. = FALSE)

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -17,7 +17,7 @@ NULL
 use_testthat <- function(pkg = ".") {
   pkg <- as.package(pkg)
 
-  check_suggested("testthat", "0.7")
+  check_suggested("testthat")
   if (uses_testthat(pkg)) {
     stop("Package already has testing infrastructure", call. = FALSE)
   }
@@ -46,7 +46,7 @@ add_test_infrastructure <- use_testthat
 use_test <- function(name, pkg = ".") {
   pkg <- as.package(pkg)
 
-  check_suggested("testthat", "0.7")
+  check_suggested("testthat")
   if (!uses_testthat(pkg)) {
     use_testthat(pkg)
   }
@@ -123,7 +123,7 @@ use_vignette <- function(name, pkg = ".") {
 #' @rdname infrastructure
 use_rcpp <- function(pkg = ".") {
   pkg <- as.package(pkg)
-  check_suggested("Rcpp", "0.10.0")
+  check_suggested("Rcpp")
 
   message("Adding Rcpp to LinkingTo and Imports")
   add_desc_package(pkg, "LinkingTo", "Rcpp")

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -17,7 +17,7 @@ NULL
 use_testthat <- function(pkg = ".") {
   pkg <- as.package(pkg)
 
-  check_testthat()
+  check_suggested("testthat", "0.7")
   if (uses_testthat(pkg)) {
     stop("Package already has testing infrastructure", call. = FALSE)
   }
@@ -46,7 +46,7 @@ add_test_infrastructure <- use_testthat
 use_test <- function(name, pkg = ".") {
   pkg <- as.package(pkg)
 
-  check_testthat()
+  check_suggested("testthat", "0.7")
   if (!uses_testthat(pkg)) {
     use_testthat(pkg)
   }

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -101,6 +101,7 @@ add_rstudio_project <- use_rstudio
 #' @rdname infrastructure
 use_vignette <- function(name, pkg = ".") {
   pkg <- as.package(pkg)
+  check_suggested("rmarkdown")
 
   add_desc_package(pkg, "Suggests", "knitr")
   add_desc_package(pkg, "Suggests", "rmarkdown")
@@ -122,6 +123,7 @@ use_vignette <- function(name, pkg = ".") {
 #' @rdname infrastructure
 use_rcpp <- function(pkg = ".") {
   pkg <- as.package(pkg)
+  check_suggested("Rcpp", "0.10.0")
 
   message("Adding Rcpp to LinkingTo and Imports")
   add_desc_package(pkg, "LinkingTo", "Rcpp")

--- a/R/lint.r
+++ b/R/lint.r
@@ -15,15 +15,9 @@
 #' cleared by calling \code{\link[lintr]{clear_cache}}.
 #' @export
 lint <- function(pkg = ".", cache = TRUE, ...) {
-  check_lintr()
+  check_suggested("lintr", "0.2.1")
   pkg <- as.package(pkg)
 
   message("Linting ", pkg$package, appendLF = FALSE)
   lintr::lint_package(pkg$path, cache = cache, ...)
-}
-
-check_lintr <- function() {
-  if (!requireNamespace("lintr", quietly = TRUE)) {
-    stop("Please install lintr", call. = FALSE)
-  }
 }

--- a/R/lint.r
+++ b/R/lint.r
@@ -15,7 +15,7 @@
 #' cleared by calling \code{\link[lintr]{clear_cache}}.
 #' @export
 lint <- function(pkg = ".", cache = TRUE, ...) {
-  check_suggested("lintr", "0.2.1")
+  check_suggested("lintr")
   pkg <- as.package(pkg)
 
   message("Linting ", pkg$package, appendLF = FALSE)

--- a/R/load.r
+++ b/R/load.r
@@ -84,8 +84,8 @@
 #' @export
 load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   export_all = TRUE, quiet = FALSE, create = NA) {
-
   pkg <- as.package(pkg, create = create)
+  check_suggested("roxygen2", "4.1.0")
 
   if (!quiet) message("Loading ", pkg$package)
 

--- a/R/load.r
+++ b/R/load.r
@@ -85,7 +85,7 @@
 load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   export_all = TRUE, quiet = FALSE, create = NA) {
   pkg <- as.package(pkg, create = create)
-  check_suggested("roxygen2", "4.1.0")
+  check_suggested("roxygen2")
 
   if (!quiet) message("Loading ", pkg$package)
 

--- a/R/missing-s3.r
+++ b/R/missing-s3.r
@@ -7,6 +7,7 @@
 #' @export
 missing_s3 <- function(pkg = ".") {
   pkg <- as.package(pkg)
+  check_suggested("roxygen2", "4.1.0")
   loaded <- load_all(pkg)
 
   # Find all S3 methods in package

--- a/R/missing-s3.r
+++ b/R/missing-s3.r
@@ -7,7 +7,7 @@
 #' @export
 missing_s3 <- function(pkg = ".") {
   pkg <- as.package(pkg)
-  check_suggested("roxygen2", "4.1.0")
+  check_suggested("roxygen2")
   loaded <- load_all(pkg)
 
   # Find all S3 methods in package

--- a/R/rcpp-attributes.r
+++ b/R/rcpp-attributes.r
@@ -5,12 +5,8 @@ compile_rcpp_attributes <- function(pkg) {
 
   # Only scan for attributes in packages explicitly linking to Rcpp
   if (links_to_rcpp(pkg)) {
-
     check_suggested("Rcpp", "0.10.0")
-
-    # Only compile attributes if we know we have the function available
-    if (utils::packageVersion("Rcpp") >= "0.10.0")
-      Rcpp::compileAttributes(pkg$path)
+    Rcpp::compileAttributes(pkg$path)
   }
 }
 

--- a/R/rcpp-attributes.r
+++ b/R/rcpp-attributes.r
@@ -5,7 +5,7 @@ compile_rcpp_attributes <- function(pkg) {
 
   # Only scan for attributes in packages explicitly linking to Rcpp
   if (links_to_rcpp(pkg)) {
-    check_suggested("Rcpp", "0.10.0")
+    check_suggested("Rcpp")
     Rcpp::compileAttributes(pkg$path)
   }
 }

--- a/R/rcpp-attributes.r
+++ b/R/rcpp-attributes.r
@@ -6,8 +6,7 @@ compile_rcpp_attributes <- function(pkg) {
   # Only scan for attributes in packages explicitly linking to Rcpp
   if (links_to_rcpp(pkg)) {
 
-    if (!requireNamespace("Rcpp", quietly = TRUE))
-      stop("Rcpp required for building this package")
+    check_suggested("Rcpp", "0.10.0")
 
     # Only compile attributes if we know we have the function available
     if (utils::packageVersion("Rcpp") >= "0.10.0")

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -35,6 +35,7 @@ revdep_check_save_summary <- function(res, log_dir = "revdep") {
 #' @rdname revdep_check
 #' @export
 revdep_check_summary <- function(res) {
+  check_suggested("knitr")
   plat <- platform_info()
   plat_df <- data.frame(setting = names(plat), value = unlist(plat))
   rownames(plat_df) <- NULL

--- a/R/run-example.r
+++ b/R/run-example.r
@@ -1,4 +1,5 @@
 run_example <- function(path, show = TRUE, test = FALSE, run = TRUE, env = new.env(parent = globalenv())) {
+  check_suggsted("evaluate")
   rd <- tools::parse_Rd(path)
 
   ex <- rd[rd_tags(rd) == "examples"]

--- a/R/run-example.r
+++ b/R/run-example.r
@@ -1,5 +1,5 @@
 run_example <- function(path, show = TRUE, test = FALSE, run = TRUE, env = new.env(parent = globalenv())) {
-  check_suggsted("evaluate")
+  check_suggested("evaluate")
   rd <- tools::parse_Rd(path)
 
   ex <- rd[rd_tags(rd) == "examples"]

--- a/R/test.r
+++ b/R/test.r
@@ -18,7 +18,7 @@
 #' @inheritParams run_examples
 #' @export
 test <- function(pkg = ".", filter = NULL, ...) {
-  check_testthat()
+  check_suggested("testthat", "0.7")
   pkg <- as.package(pkg)
 
   if (!uses_testthat(pkg) && interactive()) {
@@ -99,11 +99,4 @@ uses_testthat <- function(pkg = ".") {
   )
 
   any(dir.exists(paths))
-}
-
-
-check_testthat <- function() {
-  if (!requireNamespace("testthat", quietly = TRUE)) {
-    stop("Please install testthat", call. = FALSE)
-  }
 }

--- a/R/test.r
+++ b/R/test.r
@@ -18,7 +18,7 @@
 #' @inheritParams run_examples
 #' @export
 test <- function(pkg = ".", filter = NULL, ...) {
-  check_suggested("testthat", "0.7")
+  check_suggested("testthat")
   pkg <- as.package(pkg)
 
   if (!uses_testthat(pkg) && interactive()) {

--- a/R/upload-ftp.r
+++ b/R/upload-ftp.r
@@ -1,5 +1,5 @@
 upload_ftp <- function(file, url, verbose = FALSE){
-  check_suggested("curl", "0.9")
+  check_suggested("curl")
 
   stopifnot(file.exists(file))
   stopifnot(is.character(url))

--- a/R/upload-ftp.r
+++ b/R/upload-ftp.r
@@ -1,4 +1,6 @@
 upload_ftp <- function(file, url, verbose = FALSE){
+  check_suggested("curl", "0.9")
+
   stopifnot(file.exists(file))
   stopifnot(is.character(url))
   con <- file(file, open = "rb")

--- a/R/utils.r
+++ b/R/utils.r
@@ -117,7 +117,7 @@ file_ext <- function (x) {
 }
 
 is_bioconductor <- function(x) {
-  !is.null(x$biocviews)
+  x$package != "BiocInstaller" && !is.null(x$biocviews)
 }
 
 trim_ws <- function(x) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -42,7 +42,16 @@ render_template <- function(name, data = list()) {
 }
 
 is_installed <- function(pkg, version = 0) {
-  system.file(package = pkg) != "" && packageVersion(pkg) > version
+  installed_version <- tryCatch(utils::packageVersion(pkg), error = function(e) NA)
+  !is.na(installed_version) && installed_version >= version
+}
+
+check_suggested <- function(pkg, version = 0) {
+  if (!is_installed(pkg, version)) {
+    stop(sQuote(pkg),
+         if (version == 0) "" else paste0(" >= ", version),
+         " must be installed for this functionality", call. = FALSE)
+  }
 }
 
 read_dcf <- function(path) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -48,9 +48,18 @@ is_installed <- function(pkg, version = 0) {
 
 check_suggested <- function(pkg, version = 0) {
   if (!is_installed(pkg, version)) {
-    stop(sQuote(pkg),
-         if (version == 0) "" else paste0(" >= ", version),
-         " must be installed for this functionality", call. = FALSE)
+    msg <- paste0(sQuote(pkg),
+      if (version == 0) "" else paste0(" >= ", version),
+      " must be installed for this functionality.")
+
+    if (interactive()) {
+      message(msg, "\nWould you like to install it?")
+      if (menu(c("Yes", "No")) == 1) {
+        install.packages(pkg)
+      }
+    } else {
+      stop(msg, call. = FALSE)
+    }
   }
 }
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -69,6 +69,8 @@ check_suggested <- function(pkg, version = NULL, compare = NA) {
       message(msg, "\nWould you like to install it?")
       if (menu(c("Yes", "No")) == 1) {
         install.packages(pkg)
+      } else {
+        stop(msg, call. = FALSE)
       }
     } else {
       stop(msg, call. = FALSE)

--- a/man/package_deps.Rd
+++ b/man/package_deps.Rd
@@ -35,7 +35,7 @@ installation.}
 
 \item{object}{A \code{package_deps} object.}
 
-\item{...}{Additional arguments passed to \code{\link{install.packages}}.}
+\item{...}{Additional arguments passed to \code{install_packages}.}
 
 \item{quiet}{If \code{TRUE}, suppress output.}
 


### PR DESCRIPTION
This allows devtools to be installed in less time, such as when it is
used only to install packages and dependencies on Travis and other CIs.

If a given Suggested dependency is needed for functionality `check_suggested()` prints an informative error

```r
check_suggested("ggplot22")
#> Error: 'ggplot22' must be installed for this functionality
check_suggested("ggplot2", "2.0.0")
#> Error: 'ggplot2' >= 2.0.0 must be installed for this functionality
```
This should remove the Rcpp dependency and combined with https://github.com/hadley/httr/commit/7c68198d49ea6b2abb7255c692dddb09fbeaf7b1 it should lighten the dependency load for devtools considerably.