### PR TITLE
GitHub PAT link

### DIFF
--- a/R/infrastructure-git.R
+++ b/R/infrastructure-git.R
@@ -36,10 +36,11 @@ use_git <- function(message = "Initial commit", pkg = ".") {
 #' @section Authentication:
 #'
 #'   A new GitHub repo will be created via the GitHub API, therefore you must
-#'   provide a GitHub personal access token via the argument \code{auth_token},
-#'   which defaults to the value of the \code{GITHUB_PAT} environment variable.
-#'   Obtain a personal access token from
-#'   \url{https://github.com/settings/applications}.
+#'   provide a GitHub personal access token (PAT) via the argument
+#'   \code{auth_token}, which defaults to the value of the \code{GITHUB_PAT}
+#'   environment variable. Obtain a PAT from
+#'   \url{https://github.com/settings/tokens}. The "repo" scope is required
+#'   which is one of the default scopes for a new PAT.
 #'
 #'   The argument \code{protocol} reflects how you wish to authenticate with
 #'   GitHub for this repo in the long run. For either \code{protocol}, a remote
@@ -53,8 +54,10 @@ use_git <- function(message = "Initial commit", pkg = ".") {
 #'   \code{~/.ssh/id_rsa}, respectively, and that \code{ssh-agent} is configured
 #'   to manage any associated passphrase.
 #'
-#' @inheritParams install_github
 #' @inheritParams use_git
+#' @param auth_token Provide a personal access token (PAT) from
+#'   \url{https://github.com/settings/tokens}. Defaults to the \code{GITHUB_PAT}
+#'   environment variable.
 #' @param private If \code{TRUE}, creates a private repository.
 #' @param protocol transfer protocol, either "ssh" (the default) or "https"
 #' @family git infrastructure

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -6,7 +6,7 @@
 #' @param repo Repository address in the format
 #'   \code{username/repo[/subdir][@@ref|#pull]}. Alternatively, you can
 #'   specify \code{subdir} and/or \code{ref} using the respective parameters
-#'   (see below); if both is specified, the values in \code{repo} take
+#'   (see below); if both are specified, the values in \code{repo} take
 #'   precedence.
 #' @param username User name. Deprecated: please include username in the
 #'   \code{repo}
@@ -14,7 +14,7 @@
 #'   name, or a call to \code{\link{github_pull}}. Defaults to \code{"master"}.
 #' @param subdir subdirectory within repo that contains the R package.
 #' @param auth_token To install from a private repo, generate a personal
-#'   access token (PAT) in \url{https://github.com/settings/applications} and
+#'   access token (PAT) in \url{https://github.com/settings/tokens} and
 #'   supply to this argument. This is safer than using a password because
 #'   you can easily delete a PAT without affecting any others. Defaults to
 #'   the \code{GITHUB_PAT} environment variable.
@@ -44,7 +44,7 @@
 #' install_github("hadley/devtools")
 #'
 #' # To install from a private repo, use auth_token with a token
-#' # from https://github.com/settings/applications. You only need the
+#' # from https://github.com/settings/tokens. You only need the
 #' # repo scope. Best practice is to save your PAT in env var called
 #' # GITHUB_PAT.
 #' install_github("hadley/private", auth_token = "abc")

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -11,7 +11,7 @@ install_bitbucket(repo, username, ref = "master", subdir = NULL,
 \item{repo}{Repository address in the format
 \code{username/repo[/subdir][@ref|#pull]}. Alternatively, you can
 specify \code{subdir} and/or \code{ref} using the respective parameters
-(see below); if both is specified, the values in \code{repo} take
+(see below); if both are specified, the values in \code{repo} take
 precedence.}
 
 \item{username}{User name. Deprecated: please include username in the

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -11,7 +11,7 @@ install_github(repo, username = NULL, ref = "master", subdir = NULL,
 \item{repo}{Repository address in the format
 \code{username/repo[/subdir][@ref|#pull]}. Alternatively, you can
 specify \code{subdir} and/or \code{ref} using the respective parameters
-(see below); if both is specified, the values in \code{repo} take
+(see below); if both are specified, the values in \code{repo} take
 precedence.}
 
 \item{username}{User name. Deprecated: please include username in the
@@ -23,7 +23,7 @@ name, or a call to \code{\link{github_pull}}. Defaults to \code{"master"}.}
 \item{subdir}{subdirectory within repo that contains the R package.}
 
 \item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in \url{https://github.com/settings/applications} and
+access token (PAT) in \url{https://github.com/settings/tokens} and
 supply to this argument. This is safer than using a password because
 you can easily delete a PAT without affecting any others. Defaults to
 the \code{GITHUB_PAT} environment variable.}
@@ -58,7 +58,7 @@ install_github(c("hadley/httr@v0.4", "klutometis/roxygen#142",
 install_github("hadley/devtools")
 
 # To install from a private repo, use auth_token with a token
-# from https://github.com/settings/applications. You only need the
+# from https://github.com/settings/tokens. You only need the
 # repo scope. Best practice is to save your PAT in env var called
 # GITHUB_PAT.
 install_github("hadley/private", auth_token = "abc")

--- a/man/use_github.Rd
+++ b/man/use_github.Rd
@@ -8,11 +8,9 @@ use_github(auth_token = github_pat(), private = FALSE, pkg = ".",
   protocol = c("ssh", "https"))
 }
 \arguments{
-\item{auth_token}{To install from a private repo, generate a personal
-access token (PAT) in \url{https://github.com/settings/applications} and
-supply to this argument. This is safer than using a password because
-you can easily delete a PAT without affecting any others. Defaults to
-the \code{GITHUB_PAT} environment variable.}
+\item{auth_token}{Provide a personal access token (PAT) from
+\url{https://github.com/settings/tokens}. Defaults to the \code{GITHUB_PAT}
+environment variable.}
 
 \item{private}{If \code{TRUE}, creates a private repository.}
 
@@ -30,10 +28,11 @@ automatically. \code{\link{use_github_links}} is called to populate the
 
 
   A new GitHub repo will be created via the GitHub API, therefore you must
-  provide a GitHub personal access token via the argument \code{auth_token},
-  which defaults to the value of the \code{GITHUB_PAT} environment variable.
-  Obtain a personal access token from
-  \url{https://github.com/settings/applications}.
+  provide a GitHub personal access token (PAT) via the argument
+  \code{auth_token}, which defaults to the value of the \code{GITHUB_PAT}
+  environment variable. Obtain a PAT from
+  \url{https://github.com/settings/tokens}. The "repo" scope is required
+  which is one of the default scopes for a new PAT.
 
   The argument \code{protocol} reflects how you wish to authenticate with
   GitHub for this repo in the long run. For either \code{protocol}, a remote


### PR DESCRIPTION
  * Correct all links re: where to get a GitHub PAT.
  * Clarify scope that is needed by `devtools` ("repo") and that it's included by default in a new PAT.
  * `use_github()` used to inherit `auth_token` help from `install_github()`, complete with a confusing reference to installing from a private repo. Fixed that.

~~When I re-roxygenized, I realized it was the first time for roxygen 5.0.0. 😱~~

~~I can get rid of that commit if you wish. And just re-document the things I touched with ... older oxygen?~~