### PR TITLE
use_git(): if git is already initialized, tell the user that

### DIFF
--- a/R/infrastructure-git.R
+++ b/R/infrastructure-git.R
@@ -10,8 +10,10 @@
 use_git <- function(message = "Initial commit", pkg = ".") {
   pkg <- as.package(pkg)
 
-  if (uses_git(pkg$path))
+  if (uses_git(pkg$path)) {
+    message("* Git is already initialized")
     return(invisible())
+  }
 
   message("* Initialising repo")
   r <- git2r::init(pkg$path)


### PR DESCRIPTION
if you already have git in your project but don't realize it and run `use_git()`, it can be confusing to not see any output and think "why isn't it doing anything?". This isn't just a hypothetical, it happened today and it took us a few minutes to debug in @jennybc class