### PR TITLE
Modify pre-commit hook re: README.Rmd; fixes #979

### DIFF
--- a/inst/templates/readme-rmd-pre-commit.sh
+++ b/inst/templates/readme-rmd-pre-commit.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
+README=($(git diff --cached --name-only | grep -Ei '^README\.[R]?md$'))
+MSG="use 'git commit --no-verify' to override this check"
+
+if [[ ${#README[@]} == 0 ]]; then
+  exit 0
+fi
+
 if [[ README.Rmd -nt README.md ]]; then
-  echo "README.md is out of date; please re-knit README.Rmd"
+  echo -e "README.md is out of date; please re-knit README.Rmd\n$MSG"
+  exit 1
+elif [[ ${#README[@]} -lt 2 ]]; then
+  echo -e "README.Rmd and README.md should be both staged\n$MSG"
   exit 1
 fi


### PR DESCRIPTION
  * do nothing if neither README.Rmd nor README.md staged
  * keep checking that .md is newer than .Rmd
  * check that both are staged
  * tell user how to override