### PR TITLE
Allow credentials to be specified in install_git

### DIFF
--- a/R/install-git.r
+++ b/R/install-git.r
@@ -8,6 +8,7 @@
 #' @param branch Name of branch or tag to use, if not master.
 #' @param subdir A sub-directory within a git repository that may
 #'   contain the package we are interested in installing.
+#' @param credentials Credentials for git cloning operation.
 #' @param args DEPRECATED. A character vector providing extra arguments to
 #'   pass on to git.
 #' @param ... passed on to \code{\link{install}}

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -27,22 +27,23 @@ install_git <- function(url, subdir = NULL, branch = NULL, args = character(0),
   install_remotes(remotes, ...)
 }
 
-git_remote <- function(url, subdir = NULL, branch = NULL) {
+git_remote <- function(url, subdir = NULL, branch = NULL, credentials = NULL) {
   remote("git",
     url = url,
     subdir = subdir,
-    branch = branch
+    branch = branch,
+    credentials = credentials
   )
 }
 
 #' @export
-remote_download.git_remote <- function(x, c = NULL, quiet = FALSE) {
+remote_download.git_remote <- function(x, credentials = NULL, quiet = FALSE) {
   if (!quiet) {
     message("Downloading git repo ", x$url)
   }
 
   bundle <- tempfile()
-  git2r::clone(x$url, bundle, credentials = c, progress = FALSE)
+  git2r::clone(x$url, bundle, credentials = credentials, progress = FALSE)
 
   if (!is.null(x$branch)) {
     r <- git2r::repository(bundle)
@@ -66,6 +67,7 @@ remote_metadata.git_remote <- function(x, bundle = NULL, source = NULL) {
     RemoteUrl = x$url,
     RemoteSubdir = x$subdir,
     RemoteRef = x$ref,
-    RemoteSha = sha
+    RemoteSha = sha,
+    RemoteCredentials = x$credentials
   )
 }

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -18,12 +18,12 @@
 #' install_git("git://github.com/hadley/stringr.git")
 #' install_git("git://github.com/hadley/stringr.git", branch = "stringr-0.2")
 #'}
-install_git <- function(url, subdir = NULL, branch = NULL, args = character(0),
+install_git <- function(url, subdir = NULL, branch = NULL, credentials = NULL, args = character(0),
                         ...) {
   if (!missing(args))
     warning("`args` is deprecated", call. = FALSE)
 
-  remotes <- lapply(url, git_remote, subdir = subdir, branch = branch)
+  remotes <- lapply(url, git_remote, subdir = subdir, branch = branch, credentials = credentials)
   install_remotes(remotes, ...)
 }
 

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -37,13 +37,13 @@ git_remote <- function(url, subdir = NULL, branch = NULL, credentials = NULL) {
 }
 
 #' @export
-remote_download.git_remote <- function(x, credentials = NULL, quiet = FALSE) {
+remote_download.git_remote <- function(x, quiet = FALSE) {
   if (!quiet) {
     message("Downloading git repo ", x$url)
   }
 
   bundle <- tempfile()
-  git2r::clone(x$url, bundle, credentials = credentials, progress = FALSE)
+  git2r::clone(x$url, bundle, credentials = x$credentials, progress = FALSE)
 
   if (!is.null(x$branch)) {
     r <- git2r::repository(bundle)

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -36,13 +36,13 @@ git_remote <- function(url, subdir = NULL, branch = NULL) {
 }
 
 #' @export
-remote_download.git_remote <- function(x, quiet = FALSE) {
+remote_download.git_remote <- function(x, c = NULL, quiet = FALSE) {
   if (!quiet) {
     message("Downloading git repo ", x$url)
   }
 
   bundle <- tempfile()
-  git2r::clone(x$url, bundle, progress = FALSE)
+  git2r::clone(x$url, bundle, credentials = c, progress = FALSE)
 
   if (!is.null(x$branch)) {
     r <- git2r::repository(bundle)

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -67,7 +67,6 @@ remote_metadata.git_remote <- function(x, bundle = NULL, source = NULL) {
     RemoteUrl = x$url,
     RemoteSubdir = x$subdir,
     RemoteRef = x$ref,
-    RemoteSha = sha,
-    RemoteCredentials = x$credentials
+    RemoteSha = sha
   )
 }


### PR DESCRIPTION
I needed to specify credentials using a cred_ssh_key object in git2r, this pull request would add the ability to pass this to the git2r::clone call inside install_git. If NULL is passed, git2r looks for ssh-agent. On Windows this does not seem to work (see e.g. https://github.com/ropensci/git2r/issues/142), but it does work if the cred_ssh_key is specified.