### PR TITLE
Unregister S3 methods explicitly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* Fix longstanding lazy load database corruption issues when reloading packages
+  which define S3 methods on generics from base or other packages (#1001, @jimhester).
+
 * `document()` now only runs `update_collate()` once.
 
 * Bugfix for `Remotes: ` feature that prevented it from working if devtools was

--- a/R/install.r
+++ b/R/install.r
@@ -63,6 +63,10 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   pkg <- as.package(pkg)
   check_build_tools(pkg)
 
+  if (is_loaded(pkg)) {
+    eapply(ns_env(pkg), force, all.names = TRUE)
+  }
+
   if (!quiet) {
     message("Installing ", pkg$package)
   }

--- a/R/install.r
+++ b/R/install.r
@@ -63,6 +63,9 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   pkg <- as.package(pkg)
   check_build_tools(pkg)
 
+  # Forcing all of the promises for the current namespace now will avoid lazy-load
+  # errors when the new package is installed overtop the old one.
+  # https://stat.ethz.ch/pipermail/r-devel/2015-December/072150.html
   if (is_loaded(pkg)) {
     eapply(ns_env(pkg), force, all.names = TRUE)
   }

--- a/R/load.r
+++ b/R/load.r
@@ -96,11 +96,10 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 
   # Reloading devtools is a special case. Normally, objects in the
   # namespace become inaccessible if the namespace is unloaded before the
-  # the object has been accessed. This is kind of a hack - using as.list
-  # on the namespace accesses each object, making the objects accessible
-  # later, after the namespace is unloaded.
+  # object has been accessed. Instead we force the object so they will still be
+  # accessible.
   if (pkg$package == "devtools") {
-    as.list(ns_env(pkg))
+    eapply(ns_env(pkg), force, all.names = TRUE)
   }
 
   # Check description file is ok

--- a/R/unload.r
+++ b/R/unload.r
@@ -30,14 +30,9 @@
 unload <- function(pkg = ".") {
   pkg <- as.package(pkg)
 
-  # This is a hack to work around unloading devtools itself. The unloading
-  # process normally makes other devtools functions inaccessible,
-  # resulting in "Error in unload(pkg) : internal error -3 in R_decompress1".
-  # If we simply access them here using as.list (without calling them), then
-  # they will remain available for use later.
-  if (pkg$package == "devtools") {
-    as.list(ns_env(pkg))
-  }
+  ns <- asNamespace(pkg$package)
+
+  unregister_S3_methods(ns)
 
   # If the package was loaded with devtools, any s4 classes that were created
   # by the package need to be removed in a special way.
@@ -76,6 +71,38 @@ unload <- function(pkg = ".") {
   # Do this after detach, so that packages that have an .onUnload function
   # which unloads DLLs (like MASS) won't try to unload the DLL twice.
   unload_dll(pkg)
+}
+
+unregister_S3_methods <- function(ns) {
+  S3_methods <- getNamespaceInfo(ns, "S3methods")
+
+  unregister <- function(name, class, method) {
+    # This code was adapted from the .registerS3method internal function of
+    # base::registerS3methods
+    # https://github.com/wch/r-source/blob/05b76baa411afd3e9d0f3fc3c09a9a252a0a9100/src/library/base/R/namespace.R#L1398-L1426
+    env <-
+      if (!is.na(x <- .knownS3Generics[name])) {
+        asNamespace(x)
+      } else {
+        if(is.null(genfun <- get0(name, envir = ns))) {
+          stop(sprintf("object '%s' not found while unloading namespace '%s'",
+               name, getNamespaceName(ns)), call. = FALSE)
+        }
+        if(.isMethodsDispatchOn() && methods::is(genfun, "genericFunction")) {
+          genfun <- genfun@default  # nearly always, the S3 generic
+        }
+        if (typeof(genfun) == "closure") {
+          environment(genfun)
+        } else {
+          baseenv()
+        }
+      }
+    table <- get(".__S3MethodsTable__.", envir = env, inherits = FALSE)
+    rm(list = method, envir = table)
+  }
+  for (i in seq_len(NROW(S3_methods))) {
+    unregister(S3_methods[i, 1], S3_methods[i, 2], S3_methods[i, 3])
+  }
 }
 
 # This unloads dlls loaded by either library() or load_all()


### PR DESCRIPTION
This is a workaround for a bug in base R. unloadNamespace does not
unregister any S3 methods, so the promises are invalid if you install a
new version of a package, try to unload and re-load the package.

See https://stat.ethz.ch/pipermail/r-devel/2015-December/072150.html for
more details and a reproducible example.

This fixes the common lazy-load errors people often run into when trying
to use devtools' install functions.

Fixes #419, #503, #942, #631