### PR TITLE
Always force the promises when loading using load_all

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -94,11 +94,14 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   # in the DESCRIPTION file
   pkg$collate <- as.package(pkg$path)$collate
 
+  # Forcing all of the promises for the loaded namespace now will avoid lazy-load
+  # errors when the new package is installed overtop the old one.
+  #
   # Reloading devtools is a special case. Normally, objects in the
   # namespace become inaccessible if the namespace is unloaded before the
   # object has been accessed. Instead we force the object so they will still be
   # accessible.
-  if (pkg$package == "devtools") {
+  if (is_loaded(pkg)) {
     eapply(ns_env(pkg), force, all.names = TRUE)
   }
 

--- a/R/load.r
+++ b/R/load.r
@@ -95,7 +95,7 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   pkg$collate <- as.package(pkg$path)$collate
 
   # Forcing all of the promises for the loaded namespace now will avoid lazy-load
-  # errors when the new package is installed overtop the old one.
+  # errors when the new package is loaded overtop the old one.
   #
   # Reloading devtools is a special case. Normally, objects in the
   # namespace become inaccessible if the namespace is unloaded before the


### PR DESCRIPTION
As a continuation of #1001 you can still get lazy load errors if you use `load_all()` on a already loaded package for the same reason (promises never forced and then invalided when new code is loaded).

This was special cased for devtools so the functions would continue to work, but actually needs to be done for any package that is already loaded to avoid lazy load errors.