### PR TITLE
Show github API URL for information

### DIFF
--- a/R/install-github.r
+++ b/R/install-github.r
@@ -88,13 +88,14 @@ github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,
 
 #' @export
 remote_download.github_remote <- function(x, quiet = FALSE) {
-  if (!quiet) {
-    message("Downloading GitHub repo ", x$username, "/", x$repo, "@", x$ref)
-  }
-
   dest <- tempfile(fileext = paste0(".zip"))
   src_root <- paste0("https://", x$host, "/repos/", x$username, "/", x$repo)
   src <- paste0(src_root, "/zipball/", x$ref)
+
+  if (!quiet) {
+    message("Downloading GitHub repo ", x$username, "/", x$repo, "@", x$ref,
+            "\nfrom URL ", src)
+  }
 
   if (!is.null(x$auth_token)) {
     auth <- httr::authenticate(
@@ -109,10 +110,6 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
   if (github_has_remotes(x, auth))
     warning("GitHub repo contains submodules, may not function as expected!",
       call. = FALSE)
-
-  if (!quiet) {
-    message("Source: ", src)
-  }
 
   download(dest, src, auth)
 }

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -110,6 +110,10 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
     warning("GitHub repo contains submodules, may not function as expected!",
       call. = FALSE)
 
+  if (!quiet) {
+    message("Source: ", src)
+  }
+
   download(dest, src, auth)
 }
 


### PR DESCRIPTION
It helps to see the actual github API URL. Without this, it took me a while to find why my install_github() didn't work. It turned out to be due to the trailing space in, e.g. host="github.hostname.com/api/v3/" argument that leads to a double slashes in the final URL, e.g. "github.hostname.com/api/v3//jaimyoung/repo/zipball/master" that leads to rather uninformative error message:

client error: (403) Forbidden 

This function nicely shows "Source: https://github.hostname.com/api/v3//jaimyoung/repo/zipball/master" in the message to better reveal what went wrong.