### PR TITLE
Fix dependency install when not upgrading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 * `use_appveyor()` template now creates `failure.zip` artifact instead of
   polluting the logs with `R CMD check` output (#1017, @krlmlr, @HenrikBengtsson).
+
 * Fix a bug in the installers (`install_github`, etc.), when upgrades are
   not requested (#1013, @gaborcsardi).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 * `use_appveyor()` template now creates `failure.zip` artifact instead of
   polluting the logs with `R CMD check` output (#1017, @krlmlr, @HenrikBengtsson).
+* Fix a bug in the installers (`install_github`, etc.), when upgrades are
+  not requested (#1013, @gaborcsardi).
 
 * 'Check failed:' now includes the package name for when Ncpus>1 so you
    know which package has failed and can start looking at the output without

--- a/R/deps.R
+++ b/R/deps.R
@@ -235,7 +235,7 @@ update.package_deps <- function(object, ..., quiet = FALSE, upgrade = TRUE) {
   if (upgrade) {
     behind <- object$package[object$diff < 0L]
   } else {
-    behind <- object$package[is.na(object$available)]
+    behind <- object$package[is.na(object$installed)]
   }
   if (length(behind) > 0L) {
     install_packages(behind, repos = attr(object, "repos"),

--- a/R/deps.R
+++ b/R/deps.R
@@ -112,26 +112,34 @@ dev_package_deps <- function(pkg = ".", dependencies = NA,
   package_deps(deps, repos = repos, type = type)
 }
 
-compare_versions <- function(a, b) {
-  stopifnot(length(a) == length(b))
+## -2 = not installed, but available on CRAN
+## -1 = installed, but out of date
+##  0 = installed, most recent version
+##  1 = installed, version ahead of CRAN
+##  2 = package not on CRAN
 
-  compare_var <- function(x, y) {
-    if (is.na(y)) return(2L)
-    if (is.na(x)) return(-2L)
+compare_versions <- function(inst, cran) {
+  stopifnot(length(inst) == length(cran))
 
-    x <- package_version(x)
-    y <- package_version(y)
+  compare_var <- function(i, c) {
+    if (is.na(c)) return(2L)            # not on CRAN
+    if (is.na(i)) return(-2L)           # not installed, but on CRAN
 
-    if (x < y) {
-      -1L
-    } else if (x > y) {
-      1L
+    i <- package_version(i)
+    c <- package_version(c)
+
+    if (i < c) {
+      -1L                               # out of date
+    } else if (i > c) {
+      1L                                # ahead of CRAN
     } else {
-      0L
+      0L                                # most recent CRAN version
     }
   }
 
-  vapply(seq_along(a), function(i) compare_var(a[[i]], b[[i]]), integer(1))
+  vapply(seq_along(inst),
+    function(i) compare_var(inst[[i]], cran[[i]]),
+    integer(1))
 }
 
 install_dev_remotes <- function(pkg, ...) {
@@ -215,6 +223,12 @@ print.package_deps <- function(x, show_ok = FALSE, ...) {
     print(x[same_ver, , drop = FALSE], row.names = FALSE, right = FALSE)
   }
 }
+
+## -2 = not installed, but available on CRAN
+## -1 = installed, but out of date
+##  0 = installed, most recent version
+##  1 = installed, version ahead of CRAN
+##  2 = package not on CRAN
 
 #' @export
 #' @rdname package_deps

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -1,0 +1,62 @@
+context("update.package_deps")
+
+## -2 = not installed, but available on CRAN
+## -1 = installed, but out of date
+##  0 = installed, most recent version
+##  1 = installed, version ahead of CRAN
+##  2 = package not on CRAN
+
+test_that("update.package_deps", {
+
+  object <- data.frame(
+    stringsAsFactors = FALSE,
+    package = c("dotenv", "falsy", "magrittr"),
+    installed = c("1.0", "1.0", "1.0"),
+    available = c("1.0", NA, "1.0"),
+    diff = c(0L, 2L, 0L)
+  )
+  class(object) <- c("package_deps", "data.frame")
+
+  with_mock(
+    `devtools::install_packages` = function(...) { },
+    expect_message(
+      update(object, quiet = FALSE),
+      "Skipping 1 packages? not available: falsy"
+    )
+  )
+
+  object <- data.frame(
+    stringsAsFactors = FALSE,
+    package = c("dotenv", "falsy", "magrittr"),
+    installed = c("1.0", "1.1", "1.0"),
+    available = c("1.0", "1.0", "1.0"),
+    diff = c(0L, 1L, 0L)
+  )
+  class(object) <- c("package_deps", "data.frame")
+
+  with_mock(
+    `devtools::install_packages` = function(...) { },
+    expect_message(
+      update(object, quiet = FALSE),
+      "Skipping 1 packages? ahead of CRAN: falsy"
+    )
+  )
+
+  object <- data.frame(
+    stringsAsFactors = FALSE,
+    package = c("dotenv", "falsy", "magrittr"),
+    installed = c("1.0", "1.0", NA),
+    available = c("1.0", "1.1", "1.0"),
+    diff = c(0L, 2L, 0L)
+  )
+  class(object) <- c("package_deps", "data.frame")
+
+  with_mock(
+    `devtools::install_packages` = function(packages, ...) packages,
+    expect_equal(
+      update(object, upgrade = FALSE),
+      "magrittr"
+    )
+  )
+
+})


### PR DESCRIPTION
It was broken. Correct me please if I am mistaken.

As I see it, `NA` means that the package is not installed / available, 
and if `upgrade=FALSE` holds, then we only want to install the
ones that are not installed locally. I.e. the ones with `is.na(installed)`.

(Btw. it seems that `devtools` ignores version requirements here, but 
that is another issue.)
 
