### PR TITLE
make 'create', 'setup' more flexible (closes #966)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* `create()` and `setup()` are more permissive -- they now accept a path to
+  either a new directory or empty directory. (#966, @kevinushey)
+
 * Be more verbose about which package is installed for revdep check
   (#926, @krlmlr).
 

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -19,7 +19,8 @@ use_testthat <- function(pkg = ".") {
 
   check_suggested("testthat")
   if (uses_testthat(pkg)) {
-    stop("Package already has testing infrastructure", call. = FALSE)
+    message("* testthat is already initialized")
+    return(invisible(TRUE))
   }
 
   # Create tests/testthat and install file for R CMD CHECK
@@ -74,8 +75,10 @@ use_rstudio <- function(pkg = ".") {
 
   path <- file.path(pkg$path, paste0(pkg$package, ".Rproj"))
   if (file.exists(path)) {
+    message("* RStudio infrastructure already initialized")
     return(invisible(TRUE))
   }
+
   message("Adding RStudio project file to ", pkg$package)
 
   template_path <- system.file("templates/template.Rproj", package = "devtools")

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -74,7 +74,7 @@ use_rstudio <- function(pkg = ".") {
 
   path <- file.path(pkg$path, paste0(pkg$package, ".Rproj"))
   if (file.exists(path)) {
-    stop(pkg$package, ".Rproj already exists", call. = FALSE)
+    return(invisible(TRUE))
   }
   message("Adding RStudio project file to ", pkg$package)
 


### PR DESCRIPTION
- 'devtools::create()' works when supplied an empty directory,
- 'devtools::setup()' no longer 'stop()'s when a .Rproj file
  already exists