### PR TITLE
AppVeyor template also creates Rcheck.zip as artifact

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* `use_appveyor()` template now creates `failure.zip` artifact instead of
+  polluting the logs with `R CMD check` output (#1017, @krlmlr, @HenrikBengtsson).
+
 * 'Check failed:' now includes the package name for when Ncpus>1 so you
    know which package has failed and can start looking at the output without
    needing to wait for all packages to finish (@mattdowle).

--- a/inst/templates/appveyor.yml
+++ b/inst/templates/appveyor.yml
@@ -19,7 +19,8 @@ test_script:
   - travis-tool.sh run_tests
 
 on_failure:
-  - travis-tool.sh dump_logs
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
 
 artifacts:
   - path: '*.Rcheck\**\*.log'


### PR DESCRIPTION
instead of polluting the logs

Follow-up to #945.