### PR TITLE
More informative error message when a install_ function cannot be found.

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -174,7 +174,7 @@ dev_remote_type <- function(remotes = "") {
         mode = "function",
         inherits = FALSE),
       error = function(e) {
-        stop("Malformed remote specification '", x, "', 'devtools:::", fun_nme, "' does not exist", call. = FALSE)
+        stop("Unknown remote type", call. = FALSE)
       })
     list(repository = repo, type = type, fun = fun)
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -167,13 +167,14 @@ dev_remote_type <- function(remotes = "") {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
+    fun_nme <- paste0("install_", tolower(type))
     tryCatch(
-      fun <- get(x = paste0("install_", tolower(type)),
+      fun <- get(x = fun_nme,
         envir = asNamespace("devtools"),
         mode = "function",
         inherits = FALSE),
       error = function(e) {
-        stop("Malformed remote specification '", x, "'", call. = FALSE)
+        stop("Malformed remote specification '", x, "', 'devtools:::", fun_nme, "' does not exist", call. = FALSE)
       })
     list(repository = repo, type = type, fun = fun)
   }

--- a/R/deps.R
+++ b/R/deps.R
@@ -167,14 +167,13 @@ dev_remote_type <- function(remotes = "") {
     } else {
       stop("Malformed remote specification '", x, "'", call. = FALSE)
     }
-    fun_nme <- paste0("install_", tolower(type))
     tryCatch(
-      fun <- get(x = fun_nme,
+      fun <- get(x = paste0("install_", tolower(type)),
         envir = asNamespace("devtools"),
         mode = "function",
         inherits = FALSE),
       error = function(e) {
-        stop("Unknown remote type", call. = FALSE)
+        stop("Unknown remote type: ", type, call. = FALSE)
       })
     list(repository = repo, type = type, fun = fun)
   }

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -24,9 +24,9 @@ test_that("dev_remote_type errors", {
   expect_error(dev_remote_type("git::testthat::blah"),
     "Malformed remote specification 'git::testthat::blah'")
   expect_error(dev_remote_type("hadley::testthat"),
-    "Malformed remote specification 'hadley::testthat'")
+    "Unknown remote type")
   expect_error(dev_remote_type("SVN2::testthat"),
-    "Malformed remote specification 'SVN2::testthat', 'devtools:::install_svn2' does not exist")
+    "Unknown remote type")
 })
 
 test_that("dev_remote_type works with explicit types", {

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -24,9 +24,9 @@ test_that("dev_remote_type errors", {
   expect_error(dev_remote_type("git::testthat::blah"),
     "Malformed remote specification 'git::testthat::blah'")
   expect_error(dev_remote_type("hadley::testthat"),
-    "Unknown remote type")
+    "Unknown remote type: hadley")
   expect_error(dev_remote_type("SVN2::testthat"),
-    "Unknown remote type")
+    "Unknown remote type: SVN2")
 })
 
 test_that("dev_remote_type works with explicit types", {

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -26,7 +26,7 @@ test_that("dev_remote_type errors", {
   expect_error(dev_remote_type("hadley::testthat"),
     "Malformed remote specification 'hadley::testthat'")
   expect_error(dev_remote_type("SVN2::testthat"),
-    "Malformed remote specification 'SVN2::testthat'")
+    "Malformed remote specification 'SVN2::testthat', 'devtools:::install_svn2' does not exist")
 })
 
 test_that("dev_remote_type works with explicit types", {


### PR DESCRIPTION
Previously this gave the same error as other Malformed remotes, this should point users to the proper problem.