### PR TITLE
Handle repositories specified in Additional_repositories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* Devtools now installs packages specified in the `Additional_repositories`
+  field, such as drat repositories. (#907, #1028, @jimhester).
+
 * Be more verbose about which package is installed for revdep check
   (#926, @krlmlr).
 

--- a/R/deps.R
+++ b/R/deps.R
@@ -93,6 +93,8 @@ dev_package_deps <- function(pkg = ".", dependencies = NA,
   pkg <- as.package(pkg)
   install_dev_remotes(pkg)
 
+  repos <- c(repos, parse_additional_repositories(pkg))
+
   dependencies <- tolower(standardise_dep(dependencies))
   dependencies <- intersect(dependencies, names(pkg))
 
@@ -280,7 +282,6 @@ find_deps <- function(pkgs, available = available.packages(), top_dep = TRUE,
   unique(c(if (include_pkgs) pkgs, top_flat, rec_flat))
 }
 
-
 standardise_dep <- function(x) {
   if (identical(x, NA)) {
     c("Depends", "Imports", "LinkingTo")
@@ -315,4 +316,18 @@ update_packages <- function(pkgs, dependencies = NA,
                             type = getOption("pkgType")) {
   pkgs <- package_deps(pkgs, repos = repos, type = type)
   update(pkgs)
+}
+
+has_additional_repositories <- function(pkg) {
+  pkg <- as.package(pkg)
+
+  "additional_repositories" %in% names(pkg)
+}
+
+parse_additional_repositories <- function(pkg) {
+  pkg <- as.package(pkg)
+
+  if (has_additional_repositories(pkg)) {
+    strsplit(pkg[["additional_repositories"]], "[,[:space:]]+")[[1]]
+  }
 }


### PR DESCRIPTION
This seems to be all that is needed (assuming what is in `Additional_repositories` points to a proper 'CRAN-like' repository.

An example repository is https://github.com/rOpenGov/bibliographica, which has dependencies `gender` and `genderData` from ropensci, the rest from CRAN.

Fixes #907