### PR TITLE
package_find_repos works properly with multiple repos provided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.9.1.9000
 
+* `install_version()` now more robust when handling multiple repos (#943, #1030,
+  @jimhester).
+
 * Be more verbose about which package is installed for revdep check
   (#926, @krlmlr).
 

--- a/R/install-version.r
+++ b/R/install-version.r
@@ -41,7 +41,7 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
     }
   }
 
-  url <- paste(repos, "/src/contrib/Archive/", package.path, sep = "")
+  url <- paste(info$repo[1L], "/src/contrib/Archive/", package.path, sep = "")
   install_url(url, ...)
 }
 
@@ -50,13 +50,20 @@ package_find_repo <- function(package, repos) {
     if (length(repos) > 1)
       message("Trying ", repo)
 
-    con <- gzcon(url(sprintf("%s/src/contrib/Meta/archive.rds", repo), "rb"))
-    on.exit(close(con))
-    archive <- readRDS(con)
+    archive <-
+      tryCatch({
+        con <- gzcon(url(sprintf("%s/src/contrib/Meta/archive.rds", repo), "rb"))
+        on.exit(close(con))
+        readRDS(con)
+      },
+      warning = function(e) list(),
+      error = function(e) list())
 
     info <- archive[[package]]
-    if (!is.null(info))
+    if (!is.null(info)) {
+      info$repo <- repo
       return(info)
+    }
   }
 
   stop(sprintf("couldn't find package '%s'", package))

--- a/tests/testthat/test-install-version.R
+++ b/tests/testthat/test-install-version.R
@@ -2,12 +2,12 @@ context("Install specific version")
 
 test_that("package_find_repo() works correctly with multiple repos", {
 
-  repos <- c(CRANextras = "https://www.stats.ox.ac.uk/pub/RWin", CRAN = "https://cran.rstudio.com")
+  repos <- c(CRANextras = "http://www.stats.ox.ac.uk/pub/RWin", CRAN = "http://cran.rstudio.com")
   # ROI.plugin.glpk is the smallest package in the CRAN archive
   package <- "ROI.plugin.glpk"
   res <- package_find_repo(package, repos = repos)
 
   expect_equal(NROW(res), 1L)
-  expect_equal(res$repo, "https://cran.rstudio.com")
+  expect_equal(res$repo, "http://cran.rstudio.com")
   expect_match(rownames(res), package)
 })

--- a/tests/testthat/test-install-version.R
+++ b/tests/testthat/test-install-version.R
@@ -1,0 +1,13 @@
+context("Install specific version")
+
+test_that("package_find_repo() works correctly with multiple repos", {
+
+  repos <- c(CRANextras = "https://www.stats.ox.ac.uk/pub/RWin", CRAN = "https://cran.rstudio.com")
+  # ROI.plugin.glpk is the smallest package in the CRAN archive
+  package <- "ROI.plugin.glpk"
+  res <- package_find_repo(package, repos = repos)
+
+  expect_equal(NROW(res), 1L)
+  expect_equal(res$repo, "https://cran.rstudio.com")
+  expect_match(rownames(res), package)
+})


### PR DESCRIPTION
Fixes #943 

As far as I can tell only CRAN mirrors have a `Meta/archive.rds` file, the following all 404 (they all have valid `src/contrib/PACKAGES` though).

- http://bioconductor.org/packages/3.2/bioc/src/contrib/Meta/archive.rds
- http://packages.ropensci.org/src/contrib/Meta/archive.rds
- http://www.stats.ox.ac.uk/pub/RWin/src/contrib/Meta/archive.rds

The test fails with the current master, but succeeds with this PR.