### PR TITLE
Correct name for binary packages built on Linux

### DIFF
--- a/R/build.r
+++ b/R/build.r
@@ -40,7 +40,13 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
     args <- c("--build", args)
     cmd <- paste0("CMD INSTALL ", shQuote(pkg$path), " ",
       paste0(args, collapse = " "))
-    ext <- if (.Platform$OS.type == "windows") "zip" else "tgz"
+    if (.Platform$OS.type == "windows") {
+      ext <- ".zip"
+    } else if (grepl("darwin", R.version$os)) {
+      ext <- ".tgz"
+    } else {
+      ext <- paste0("_R_", Sys.getenv("R_PLATFORM"), ".tar.gz")
+    }
   } else {
     args <- c(args, "--no-resave-data")
 
@@ -55,7 +61,7 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
     cmd <- paste0("CMD build ", shQuote(pkg$path), " ",
       paste0(args, collapse = " "))
 
-    ext <- "tar.gz"
+    ext <- ".tar.gz"
   }
 
   # Create temporary library to ensure that default library doesn't get
@@ -65,7 +71,7 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
   on.exit(unlink(temp_lib, recursive = TRUE), add = TRUE)
 
   withr::with_libpaths(c(temp_lib, .libPaths()), R(cmd, path, quiet = quiet))
-  targz <- paste0(pkg$package, "_", pkg$version, ".", ext)
+  targz <- paste0(pkg$package, "_", pkg$version, ext)
 
   file.path(path, targz)
 }

--- a/tests/testthat/test-build.r
+++ b/tests/testthat/test-build.r
@@ -1,0 +1,13 @@
+context("build")
+
+test_that("source builds return correct filenames", {
+  path <- devtools::build("testNamespace", path=tempdir(),
+                          quiet=TRUE)
+  expect_true(file.exists(path))
+})
+
+test_that("binary builds return correct filenames", {
+  path <- devtools::build("testNamespace", binary=TRUE, path=tempdir(),
+                          quiet=TRUE)
+  expect_true(file.exists(path))
+})


### PR DESCRIPTION
On Linux, with devtools from GitHub (050c964), the name of the built binary is incorrect.  Apparently the correct extension is "tar.gz" (not "tgz") and additional platform information is included (from the `R_PLATFORM` environment variable).

```
> (path <- devtools::build("tests/testthat/testNamespace", binary=TRUE, path=tempdir()))
'/usr/lib/R/bin/R' --no-site-file --no-environ --no-save --no-restore CMD  \
  INSTALL '/home/rich/src/devtools/tests/testthat/testNamespace' --build 

* installing to library ‘/tmp/Rtmp1Sg8Nn/file135ddcab9a6’
* installing *source* package ‘testNamespace’ ...
** R
** preparing package for lazy loading
** help
No man pages found in package  ‘testNamespace’ 
*** installing help indices
** building package indices
** testing if installed package can be loaded
* creating tarball
packaged installation of ‘testNamespace’ as ‘testNamespace_0.1_R_x86_64-pc-linux-gnu.tar.gz’
* DONE (testNamespace)
[1] "/tmp/Rtmp1Sg8Nn/testNamespace_0.1.tgz"
> file.exists(path)
[1] FALSE
> dir(tempdir())
[1] "Rprofile-devtools"                             
[2] "testNamespace_0.1_R_x86_64-pc-linux-gnu.tar.gz"
```

The pull request here uses the same logic as `tools:::.install_packages()` with the `tar_up=TRUE`.

```
> (path <- devtools::build("tests/testthat/testNamespace", binary=TRUE, path=tempdir()))
'/usr/lib/R/bin/R' --no-site-file --no-environ --no-save --no-restore CMD  \
  INSTALL '/home/rich/src/devtools/tests/testthat/testNamespace' --build 

* installing to library ‘/tmp/Rtmpjr5PBQ/file145724f55c26’
* installing *source* package ‘testNamespace’ ...
** R
** preparing package for lazy loading
** help
No man pages found in package  ‘testNamespace’ 
*** installing help indices
** building package indices
** testing if installed package can be loaded
* creating tarball
packaged installation of ‘testNamespace’ as ‘testNamespace_0.1_R_x86_64-pc-linux-gnu.tar.gz’
* DONE (testNamespace)
[1] "/tmp/Rtmpjr5PBQ/testNamespace_0.1_R_x86_64-pc-linux-gnu.tar.gz"
> file.exists(path)
[1] TRUE
```
