### PR TITLE
Print message if SHA1 has not changed.

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -60,10 +60,13 @@ github_tag <- function(username, repo, ref = "master") {
 #'
 #' @keywords internal
 #' @export
-github_pat <- function() {
+github_pat <- function(quiet = FALSE) {
   pat <- Sys.getenv('GITHUB_PAT')
   if (identical(pat, "")) return(NULL)
 
-  message("Using github PAT from envvar GITHUB_PAT")
+  if (!quiet) {
+    message("Using github PAT from envvar GITHUB_PAT")
+  }
+
   pat
 }

--- a/R/install-bitbucket.r
+++ b/R/install-bitbucket.r
@@ -20,16 +20,17 @@
 #' install_bitbucket("dannavarro/lsr-package")
 #' }
 install_bitbucket <- function(repo, username, ref = "master", subdir = NULL,
-                              auth_user = NULL, password = NULL, force = FALSE, ...) {
+                              auth_user = NULL, password = NULL, force = FALSE,
+                              quiet = FALSE, ...) {
 
   remotes <- lapply(repo, bitbucket_remote, username = username, ref = ref,
     subdir = subdir, auth_user = auth_user, password = password)
 
   if (!isTRUE(force)) {
-    remotes <- Filter(different_sha, remotes)
+    remotes <- Filter(function(x) different_sha(x, quiet = quiet), remotes)
   }
 
-  install_remotes(remotes, ...)
+  install_remotes(remotes, quiet = quiet, ...)
 }
 
 bitbucket_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -12,6 +12,7 @@
 #'   pass on to git.
 #' @param force Force installation even if the git SHA1 has not changed since
 #'   the previous install.
+#' @param quiet if \code{TRUE} suppresses output from this function.
 #' @param ... passed on to \code{\link{install}}
 #' @export
 #' @family package installation
@@ -21,17 +22,17 @@
 #' install_git("git://github.com/hadley/stringr.git", branch = "stringr-0.2")
 #'}
 install_git <- function(url, subdir = NULL, branch = NULL, args = character(0),
-                        force = FALSE, ...) {
+                        force = FALSE, quiet = FALSE, ...) {
   if (!missing(args))
     warning("`args` is deprecated", call. = FALSE)
 
   remotes <- lapply(url, git_remote, subdir = subdir, branch = branch)
 
   if (!isTRUE(force)) {
-    remotes <- Filter(different_sha, remotes)
+    remotes <- Filter(function(x) different_sha(x, quiet = quiet), remotes)
   }
 
-  install_remotes(remotes, ...)
+  install_remotes(remotes, quiet = quiet, ...)
 }
 
 git_remote <- function(url, subdir = NULL, branch = NULL) {

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -22,6 +22,7 @@
 #'   hostname, for example, \code{"github.hostname.com/api/v3"}.
 #' @param force Force installation even if the git SHA1 has not changed since
 #'   the previous install.
+#' @param quiet if \code{TRUE} suppresses output from this function.
 #' @param ... Other arguments passed on to \code{\link{install}}.
 #' @details
 #' Attempting to install from a source repository that uses submodules
@@ -54,18 +55,19 @@
 #' }
 install_github <- function(repo, username = NULL,
                            ref = "master", subdir = NULL,
-                           auth_token = github_pat(),
+                           auth_token = github_pat(quiet),
                            host = "api.github.com",
-                           force = FALSE, ...) {
+                           force = FALSE, quiet = FALSE,
+                           ...) {
 
   remotes <- lapply(repo, github_remote, username = username, ref = ref,
     subdir = subdir, auth_token = auth_token, host = host)
 
   if (!isTRUE(force)) {
-    remotes <- Filter(different_sha, remotes)
+    remotes <- Filter(function(x) different_sha(x, quiet = quiet), remotes)
   }
 
-  install_remotes(remotes, ...)
+  install_remotes(remotes, quiet = quiet, ...)
 }
 
 github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -67,8 +67,15 @@ different_sha <- function(remote = NULL,
     local_sha <- local_sha(remote_package_name(remote))
   }
 
-  different <- remote_sha != local_sha
-  isTRUE(different) || is.na(different)
+  different <- isTRUE(remote_sha != local_sha)
+  different <- different || is.na(different)
+  if (!different) {
+     message(
+       "Skipping install for ", sub("_remote", "", class(remote)[1L]), " remote,",
+       " the SHA1 has not changed since last install.\n",
+       "  Use `force = TRUE` to force installation")
+  }
+  different
 }
 
 local_sha <- function(name) {

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -58,7 +58,8 @@ is.remote <- function(x) inherits(x, "remote")
 
 different_sha <- function(remote = NULL,
                           remote_sha = NULL,
-                          local_sha = NULL) {
+                          local_sha = NULL,
+                          quiet = FALSE, ...) {
   if (is.null(remote_sha)) {
     remote_sha <- remote_sha(remote)
   }
@@ -67,15 +68,15 @@ different_sha <- function(remote = NULL,
     local_sha <- local_sha(remote_package_name(remote))
   }
 
-  different <- isTRUE(remote_sha != local_sha)
-  different <- different || is.na(different)
-  if (!different) {
+  same <- remote_sha == local_sha
+  same <- isTRUE(same) && !is.na(same)
+  if (!quiet && same) {
      message(
        "Skipping install for ", sub("_remote", "", class(remote)[1L]), " remote,",
-       " the SHA1 has not changed since last install.\n",
+       " the SHA1 (", substr(local_sha, 1L, 8L), ") has not changed since last install.\n",
        "  Use `force = TRUE` to force installation")
   }
-  different
+  !same
 }
 
 local_sha <- function(name) {

--- a/man/github_pat.Rd
+++ b/man/github_pat.Rd
@@ -4,7 +4,7 @@
 \alias{github_pat}
 \title{Retrieve Github personal access token.}
 \usage{
-github_pat()
+github_pat(quiet = FALSE)
 }
 \description{
 A github personal access token

--- a/man/install_bitbucket.Rd
+++ b/man/install_bitbucket.Rd
@@ -5,7 +5,7 @@
 \title{Install a package directly from bitbucket}
 \usage{
 install_bitbucket(repo, username, ref = "master", subdir = NULL,
-  auth_user = NULL, password = NULL, force = FALSE, ...)
+  auth_user = NULL, password = NULL, force = FALSE, quiet = FALSE, ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -30,6 +30,8 @@ to \code{username})}
 
 \item{force}{Force installation even if the git SHA1 has not changed since
 the previous install.}
+
+\item{quiet}{if \code{TRUE} suppresses output from this function.}
 
 \item{...}{Other arguments passed on to \code{\link{install}}.}
 }

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -5,7 +5,7 @@
 \title{Install a package from a git repository}
 \usage{
 install_git(url, subdir = NULL, branch = NULL, args = character(0),
-  force = FALSE, ...)
+  force = FALSE, quiet = FALSE, ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -21,6 +21,8 @@ pass on to git.}
 
 \item{force}{Force installation even if the git SHA1 has not changed since
 the previous install.}
+
+\item{quiet}{if \code{TRUE} suppresses output from this function.}
 
 \item{...}{passed on to \code{\link{install}}}
 }

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -5,7 +5,8 @@
 \title{Attempts to install a package directly from GitHub.}
 \usage{
 install_github(repo, username = NULL, ref = "master", subdir = NULL,
-  auth_token = github_pat(), host = "api.github.com", force = FALSE, ...)
+  auth_token = github_pat(quiet), host = "api.github.com", force = FALSE,
+  quiet = FALSE, ...)
 }
 \arguments{
 \item{repo}{Repository address in the format
@@ -33,6 +34,8 @@ hostname, for example, \code{"github.hostname.com/api/v3"}.}
 
 \item{force}{Force installation even if the git SHA1 has not changed since
 the previous install.}
+
+\item{quiet}{if \code{TRUE} suppresses output from this function.}
 
 \item{...}{Other arguments passed on to \code{\link{install}}.}
 }


### PR DESCRIPTION
Message currently works as follows
``` r
install_github("jimhester/covr")
#> Skipping install for github remote, the SHA1 has not changed since last install.
#>   Use `force = TRUE` to force installation
```

Let me know if you want to tweak the copy or if it should only be printed interactively.

Fixes #1040