### PR TITLE
flag vignettes entitled "Vignette Title"; closes #960

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,8 @@
 
 * `check_dev_versions()` checks only package dependencies (#983).
 
+* `check_vignette_titles()` added to flag vignettes entitled "Vignette Title" (#960, @jennybc). 
+
 * `check_man()` replaces `check_doc()` (since most other functions are
   named after the corresponding directory). `check_doc()` will hang around
   as an alias for the forseeable future (#958).

--- a/R/check-devtools.r
+++ b/R/check-devtools.r
@@ -14,6 +14,7 @@ release_checks <- function(pkg = ".", built_path = NULL) {
 
   check_version(pkg)
   check_dev_versions(pkg)
+  check_vignette_titles(pkg)
 }
 
 check_dev_versions <- function(pkg = ".") {
@@ -58,6 +59,37 @@ check_version <- function(pkg = ".") {
   message(
     "WARNING",
     "\n  Version (", pkg$version, ") should have exactly three components"
+  )
+
+  return(invisible(FALSE))
+
+}
+
+check_vignette_titles <- function(pkg = ".") {
+  pkg <- as.package(pkg)
+
+  vigns <- tools::pkgVignettes(dir = pkg$path)
+  if (length(vigns$docs) == 0) return()
+
+  message("Checking vignette titles... ",
+          appendLF = FALSE)
+  has_Vignette_Title <- function(v, n) {
+    h <- readLines(v, n = n)
+    any(grepl("Vignette Title", h))
+  }
+  v <- stats::setNames(vigns$docs, basename(vigns$docs))
+  has_VT <- vapply(v, has_Vignette_Title, logical(1), n = 30)
+
+  if (!any(has_VT)) {
+    message("OK")
+    return(invisible(TRUE))
+  }
+
+  message(
+    "WARNING",
+    "\n  placeholder 'Vignette Title' detected in 'title' field and/or ",
+    "\n  'VignetteIndexEntry' for these vignettes:\n",
+    paste(" ", names(has_VT)[has_VT], collapse = "\n")
   )
 
   return(invisible(FALSE))

--- a/R/vignettes.r
+++ b/R/vignettes.r
@@ -1,7 +1,7 @@
 #' Build package vignettes.
 #'
 #' Builds package vignettes using the same algorithm that \code{R CMD build}
-#' does. This means including non-Sweave vignettes, using make  files (if
+#' does. This means including non-Sweave vignettes, using makefiles (if
 #' present), and copying over extra files. You need to ensure that these
 #' files are not included in the built package - ideally they should not
 #' be checked into source, or at least excluded with \code{.Rbuildignore}

--- a/man/build_vignettes.Rd
+++ b/man/build_vignettes.Rd
@@ -16,7 +16,7 @@ argument \code{dependencies} of \code{\link{install.packages}}.}
 }
 \description{
 Builds package vignettes using the same algorithm that \code{R CMD build}
-does. This means including non-Sweave vignettes, using make  files (if
+does. This means including non-Sweave vignettes, using makefiles (if
 present), and copying over extra files. You need to ensure that these
 files are not included in the built package - ideally they should not
 be checked into source, or at least excluded with \code{.Rbuildignore}


### PR DESCRIPTION
Here's what it does for a package with multiple offending vignettes:

```
Running additional devtools checks for rpivotTable
Checking version number... WARNING
Version (0.1.5.7) should have exactly three components
Checking for dependencies on development versions... OK
Checking vignette titles... WARNING
  placeholder 'Vignette Title' detected in 'title' field and/or
  'VignetteIndexEntry' for these vignettes:
  NEWS.Rmd
  rpivotTableIntroduction.Rmd
```