### PR TITLE
extend use_package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: devtools
 Title: Tools to Make Developing R Packages Easier
-Version: 1.10.0.9000
+Version: 1.11.0.0
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
     person("Winston", "Chang", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: devtools
 Title: Tools to Make Developing R Packages Easier
-Version: 1.11.0.0
+Version: 1.10.0.9001
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
     person("Winston", "Chang", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: devtools
 Title: Tools to Make Developing R Packages Easier
-Version: 1.10.0.9001
+Version: 1.10.0.9000
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
     person("Winston", "Chang", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# devtools 1.10.0.9001
+
+## New features
+
+* `use_package()` has gotten its signature extended to include arguments `version`,
+  and `compare` which allow users to insert more fine-grained dependency 
+  specifications in their DESCRIPTION files (e.g. `utils (>= 3.2.0)`).
+  
+## Bug fixes and minor improvements
+
+* unit tests for `use_package()` have been implemented (these include checks for
+  idempotency).
+
 # devtools 1.10.0.9000
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,6 @@
-# devtools 1.10.0.9001
-
-## New features
-
 * `use_package()` has gotten its signature extended to include arguments `version`,
   and `compare` which allow users to insert more fine-grained dependency 
   specifications in their DESCRIPTION files (e.g. `utils (>= 3.2.0)`).
-  
-## Bug fixes and minor improvements
-
 * unit tests for `use_package()` have been implemented (these include checks for
   idempotency).
 

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -304,7 +304,8 @@ use_package_doc <- function(pkg = ".") {
 #' @param version Value indicating whether \code{package}'s version should be included
 #'   in \code{pkg}'s DESCRIPTION. Either \code{NULL}, \code{TRUE}, or a valid version
 #'   string. If \code{version} is \code{TRUE}, \code{package}'s current version
-#'   will be used. See examples.
+#'   will be used (see examples). If \code{version} is a string that is not a
+#'   valid version, an error will be thrown.
 #' @param compare The comparator used for \code{package}'s version. All valid
 #'   CRAN comparators (i.e. \code{==}, \code{>=}, \code{<=}, \code{>}, and
 #'   \code{<}) are accepted, but not considered unless \code{version} is
@@ -335,6 +336,9 @@ use_package <- function(package, type = "Imports", pkg = ".", version = NULL,
     # add a version dependency
     if (isTRUE(version)) {
       version <- packageVersion(package)
+    } else {
+      # check that version is a valid version string
+      version <- package_version(version)
     }
     compare <- match.arg(compare)
     package_txt <- paste0(package, " (", compare, " ", version, ")")

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -375,7 +375,9 @@ add_desc_package <- function(pkg = ".", field, name) {
     new <- name
     changed <- TRUE
   } else {
-    if (!grepl(name, old)) {
+    # used fixed regexp pattern to account for
+    # name == 'package (>= packageVersion)'
+    if (!grepl(name, old, fixed = TRUE)) {
       new <- paste0(old, ",\n    ", name)
       changed <- TRUE
     } else {

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -325,8 +325,8 @@ build_package_txt <- function(package, version = NULL,
 #' @param version Value indicating whether \code{package}'s version should be included
 #'   in \code{pkg}'s DESCRIPTION. Either \code{NULL}, \code{TRUE}, or a valid version
 #'   string. If \code{version} is \code{TRUE}, \code{package}'s current version
-#'   will be used (see examples). If \code{version} is a string that is not a
-#'   valid version, an error will be thrown.
+#'   will be used (see examples).
+#'
 #' @param compare The comparator used for \code{package}'s version. All valid
 #'   CRAN comparators (i.e. \code{==}, \code{>=}, \code{<=}, \code{>}, and
 #'   \code{<}) are accepted, but not considered unless \code{version} is
@@ -350,16 +350,15 @@ use_package <- function(package, type = "Imports", pkg = ".", version = NULL,
 
   if (!is_installed(package)) {
     stop(package, " must be installed before you can take a dependency on it",
-         call. = FALSE)
+      call. = FALSE)
   }
-
-  package_txt <- build_package_txt(package, version, compare)
 
   types <- c("Imports", "Depends", "Suggests", "Enhances", "LinkingTo")
   names(types) <- tolower(types)
 
   type <- types[[match.arg(tolower(type), names(types))]]
 
+  package_txt <- build_package_txt(package, version, compare)
   message("Adding ", package_txt, " to ", type)
   add_desc_package(pkg, type, package_txt)
 

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -291,6 +291,27 @@ use_package_doc <- function(pkg = ".") {
   writeLines(out, file.path(pkg$path, path))
 }
 
+# help function for use_package
+# takes the same arguments as use_package
+build_package_txt <- function(package, version = NULL,
+                              compare =  c(">=", ">", "==", "<=", "<")) {
+  if (!is.null(version)) {
+    # add a version dependency
+    if (isTRUE(version)) {
+      version <- packageVersion(package)
+    } else {
+      # check that version is a valid version string
+      version <- package_version(version)
+    }
+    compare <- match.arg(compare)
+    package_txt <- paste0(package, " (", compare, " ", version, ")")
+  } else {
+    package_txt <- package
+  }
+
+  return(package_txt)
+}
+
 #' Use specified package.
 #'
 #' This adds a dependency to DESCRIPTION and offers a little advice
@@ -332,19 +353,7 @@ use_package <- function(package, type = "Imports", pkg = ".", version = NULL,
          call. = FALSE)
   }
 
-  if (!is.null(version)) {
-    # add a version dependency
-    if (isTRUE(version)) {
-      version <- packageVersion(package)
-    } else {
-      # check that version is a valid version string
-      version <- package_version(version)
-    }
-    compare <- match.arg(compare)
-    package_txt <- paste0(package, " (", compare, " ", version, ")")
-  } else {
-    package_txt <- package
-  }
+  package_txt <- build_package_txt(package, version, compare)
 
   types <- c("Imports", "Depends", "Suggests", "Enhances", "LinkingTo")
   names(types) <- tolower(types)

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -292,9 +292,8 @@ use_package_doc <- function(pkg = ".") {
 }
 
 # help function for use_package
-# takes the same arguments as use_package
-build_package_txt <- function(package, version = NULL,
-                              compare =  c(">=", ">", "==", "<=", "<")) {
+# takes the same `package` and `version` as use_package
+build_package_txt <- function(package, version = NULL) {
   if (!is.null(version)) {
     # add a version dependency
     if (isTRUE(version)) {
@@ -303,7 +302,7 @@ build_package_txt <- function(package, version = NULL,
       # check that version is a valid version string
       version <- package_version(version)
     }
-    compare <- match.arg(compare)
+    compare <- ">=" # define compare in case future support for other versions is desired
     package_txt <- paste0(package, " (", compare, " ", version, ")")
   } else {
     package_txt <- package
@@ -323,14 +322,9 @@ build_package_txt <- function(package, version = NULL,
 #' @param pkg package description, can be path or package name. See
 #'   \code{\link{as.package}} for more information.
 #' @param version Value indicating whether \code{package}'s version should be included
-#'   in \code{pkg}'s DESCRIPTION. Either \code{NULL}, \code{TRUE}, or a valid version
-#'   string. If \code{version} is \code{TRUE}, \code{package}'s current version
-#'   will be used (see examples).
-#'
-#' @param compare The comparator used for \code{package}'s version. All valid
-#'   CRAN comparators (i.e. \code{==}, \code{>=}, \code{<=}, \code{>}, and
-#'   \code{<}) are accepted, but not considered unless \code{version} is
-#'   non-\code{NULL}.
+#'   in \code{pkg}'s DESCRIPTION as a minimum version number. Either \code{NULL},
+#'   \code{TRUE}, or a valid version string. If \code{version} is \code{TRUE},
+#'   \code{package}'s current version will be used (see examples).
 #' @family infrastructure
 #' @export
 #' @examples
@@ -338,12 +332,9 @@ build_package_txt <- function(package, version = NULL,
 #' use_package("ggplot2")
 #' use_package("dplyr", "suggests")
 #' use_package("devtools", version = TRUE) # "devtools (>= 1.10.0.9000)"
-#' use_package("devtools", version = TRUE, compare = "==") # "devtools (== 1.10.0.9000)"
 #' use_package("devtools", version = "1.10") # "devtools (>= 1.10)"
-#' use_package("devtools", version = "1.10", compare = ">") # "devtools (> 1.10)"
 #' }
-use_package <- function(package, type = "Imports", pkg = ".", version = NULL,
-                        compare =  c(">=", ">", "==", "<=", "<")) {
+use_package <- function(package, type = "Imports", pkg = ".", version = NULL) {
 
   stopifnot(is.character(package), length(package) == 1)
   stopifnot(is.character(type), length(type) == 1)
@@ -358,7 +349,7 @@ use_package <- function(package, type = "Imports", pkg = ".", version = NULL,
 
   type <- types[[match.arg(tolower(type), names(types))]]
 
-  package_txt <- build_package_txt(package, version, compare)
+  package_txt <- build_package_txt(package, version)
   message("Adding ", package_txt, " to ", type)
   add_desc_package(pkg, type, package_txt)
 

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -4,7 +4,8 @@
 \alias{use_package}
 \title{Use specified package.}
 \usage{
-use_package(package, type = "Imports", pkg = ".", version = "none")
+use_package(package, type = "Imports", pkg = ".", version = NULL,
+  compare = c(">=", ">", "==", "<=", "<"))
 }
 \arguments{
 \item{package}{Name of package to depend on.}
@@ -15,8 +16,15 @@ use_package(package, type = "Imports", pkg = ".", version = "none")
 \item{pkg}{package description, can be path or package name. See
 \code{\link{as.package}} for more information.}
 
-\item{version}{Type of comparison for the version of \code{package}: must be
-one of "minimum", "exact", or "none".}
+\item{version}{Value indicating whether \code{package}'s version should be included
+in \code{pkg}'s DESCRIPTION. Either \code{NULL}, \code{TRUE}, or a valid version
+string. If \code{version} is \code{TRUE}, \code{package}'s current version
+will be used. See examples.}
+
+\item{compare}{The comparator used for \code{package}'s version. All valid
+CRAN comparators (i.e. \code{==}, \code{>=}, \code{<=}, \code{>}, and
+\code{<}) are accepted, but not considered unless \code{version} is
+non-\code{NULL}.}
 }
 \description{
 This adds a dependency to DESCRIPTION and offers a little advice
@@ -26,8 +34,10 @@ about how to best use it.
 \dontrun{
 use_package("ggplot2")
 use_package("dplyr", "suggests")
-use_package("stringr", "suggests", version="min")
-
+use_package("devtools", version = TRUE) # "devtools (>= 1.10.0.9000)"
+use_package("devtools", version = TRUE, compare = "==") # "devtools (== 1.10.0.9000)"
+use_package("devtools", version = "1.10") # "devtools (>= 1.10)"
+use_package("devtools", version = "1.10", compare = ">") # "devtools (> 1.10)"
 }
 }
 \seealso{

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -4,7 +4,7 @@
 \alias{use_package}
 \title{Use specified package.}
 \usage{
-use_package(package, type = "Imports", pkg = ".")
+use_package(package, type = "Imports", pkg = ".", version = "none")
 }
 \arguments{
 \item{package}{Name of package to depend on.}
@@ -14,6 +14,9 @@ use_package(package, type = "Imports", pkg = ".")
 
 \item{pkg}{package description, can be path or package name. See
 \code{\link{as.package}} for more information.}
+
+\item{version}{Type of comparison for the version of \code{package}: must be
+one of "minimum", "exact", or "none".}
 }
 \description{
 This adds a dependency to DESCRIPTION and offers a little advice
@@ -23,6 +26,7 @@ about how to best use it.
 \dontrun{
 use_package("ggplot2")
 use_package("dplyr", "suggests")
+use_package("stringr", "suggests", version="min")
 
 }
 }

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -4,8 +4,7 @@
 \alias{use_package}
 \title{Use specified package.}
 \usage{
-use_package(package, type = "Imports", pkg = ".", version = NULL,
-  compare = c(">=", ">", "==", "<=", "<"))
+use_package(package, type = "Imports", pkg = ".", version = NULL)
 }
 \arguments{
 \item{package}{Name of package to depend on.}
@@ -17,15 +16,9 @@ use_package(package, type = "Imports", pkg = ".", version = NULL,
 \code{\link{as.package}} for more information.}
 
 \item{version}{Value indicating whether \code{package}'s version should be included
-in \code{pkg}'s DESCRIPTION. Either \code{NULL}, \code{TRUE}, or a valid version
-string. If \code{version} is \code{TRUE}, \code{package}'s current version
-will be used (see examples). If \code{version} is a string that is not a
-valid version, an error will be thrown.}
-
-\item{compare}{The comparator used for \code{package}'s version. All valid
-CRAN comparators (i.e. \code{==}, \code{>=}, \code{<=}, \code{>}, and
-\code{<}) are accepted, but not considered unless \code{version} is
-non-\code{NULL}.}
+in \code{pkg}'s DESCRIPTION as a minimum version number. Either \code{NULL},
+\code{TRUE}, or a valid version string. If \code{version} is \code{TRUE},
+\code{package}'s current version will be used (see examples).}
 }
 \description{
 This adds a dependency to DESCRIPTION and offers a little advice
@@ -36,9 +29,7 @@ about how to best use it.
 use_package("ggplot2")
 use_package("dplyr", "suggests")
 use_package("devtools", version = TRUE) # "devtools (>= 1.10.0.9000)"
-use_package("devtools", version = TRUE, compare = "==") # "devtools (== 1.10.0.9000)"
 use_package("devtools", version = "1.10") # "devtools (>= 1.10)"
-use_package("devtools", version = "1.10", compare = ">") # "devtools (> 1.10)"
 }
 }
 \seealso{

--- a/man/use_package.Rd
+++ b/man/use_package.Rd
@@ -19,7 +19,8 @@ use_package(package, type = "Imports", pkg = ".", version = NULL,
 \item{version}{Value indicating whether \code{package}'s version should be included
 in \code{pkg}'s DESCRIPTION. Either \code{NULL}, \code{TRUE}, or a valid version
 string. If \code{version} is \code{TRUE}, \code{package}'s current version
-will be used. See examples.}
+will be used (see examples). If \code{version} is a string that is not a
+valid version, an error will be thrown.}
 
 \item{compare}{The comparator used for \code{package}'s version. All valid
 CRAN comparators (i.e. \code{==}, \code{>=}, \code{<=}, \code{>}, and

--- a/tests/testthat/test-infrastructure.r
+++ b/tests/testthat/test-infrastructure.r
@@ -90,20 +90,17 @@ test_that("add_desc_package is idempotent", {
   # do it twice and check that the description file is the same as in
   # the second time.
   import_text <- "testPackage (>= 1.0.0)"
-  descriptions <- lapply(c(1,2), function(call_repetition) {
-    if (call_repetition == 1) {
-      # first time function is being called... It should return TRUE.
-      expect_true(add_desc_package("testData", "Imports", import_text))
-    } else {
-      # function should report that nothing changed
-      expect_false(add_desc_package("testData", "Imports", import_text))
-    }
 
-    return(read_dcf(path_to_test_desc))
-    })
+  # first time function is being called... It should return TRUE.
+  expect_true(add_desc_package("testData", "Imports", import_text))
+  first_output <- read_dcf(path_to_test_desc)
+
+  # function should report that nothing changed
+  expect_false(add_desc_package("testData", "Imports", import_text))
+  second_output <- read_dcf(path_to_test_desc)
 
   # finally, check for idempotency.
-  expect_equal(descriptions[1], descriptions[2])
+  expect_equal(first_output, second_output)
 })
 
 test_that("use_package throws error with invalid 'version' argument", {
@@ -111,44 +108,3 @@ test_that("use_package throws error with invalid 'version' argument", {
   # use the tests/testthat/testData/ as test package.
   expect_error(use_package("utils", "Imports", "testData", "invalid"))
 })
-
-# Set up a grid of the potential inputs to use_package and individual test
-# them for correctness and behaviour. These are only partial tests, since the
-# checks for idempotency, error-throwing, and making sure *only* the indicated
-# fields are affected, are all handled above.
-test_that("use_package can modify Imports, Suggests and Depends", {
-  # use tests/testthat/testData as testing package
-  path_to_test_desc <- file.path("testData", "DESCRIPTION")
-  old_desc <- read_dcf(path_to_test_desc)
-
-  # be sure to return the description to original state on exit
-  on.exit(write_dcf(path_to_test_desc, old_desc))
-
-  # create all possible input scenarios
-  types <- c("Imports", "Suggests", "Depends")
-  package <- "utils"
-  pkg <- "testData"
-  versions <- list(NULL, TRUE, "3.0.0")
-
-  # we expect use_package to be able to add:
-  # utils, utils (>= 3.2.3) and utils (>= 3.0.0) to
-  # Imports, Suggests, and Depends DESCRIPTION sections:
-  sapply(types, function(type) {
-    sapply(versions, function(version) {
-
-      on.exit(write_dcf(path_to_test_desc, old_desc))
-
-      # expect a message with each call
-      expect_message(use_package(package, type, pkg, version), regexp = NULL)
-
-      # check that section was properly modified; note, that we don't have
-      # to check that other sections are NOT being modified since we assume
-      # that this behaviour is being preserved by add_desc_package().
-      new_desc <- read_dcf(path_to_test_desc)
-      expect_equal(new_desc[[type]], build_package_txt(package, version))
-    })
-  })
-})
-
-
-


### PR DESCRIPTION
- created a 'version' parameter that allows for version comparisons to
  be incorporated into DESCRIPTION. E.g., `version='min'` would introduce
  "package (>= packageVersion)" into the selected type of dependency...
- bumped version number to 1.11.0.0
