### PR TITLE
Use the last archived version if version == NULL

### DIFF
--- a/R/install-version.r
+++ b/R/install-version.r
@@ -69,14 +69,12 @@ package_find_repo <- function(package, repos) {
         }
       })))
 
-  # order by the path (which contains the version) and then by modified time.
-  # This needs to be done in case the same package is available from multiple
-  # repositories.
-  res <- res[order(res$path, res$mtime), ]
-
   if (NROW(res) == 0) {
     stop(sprintf("couldn't find package '%s'", package))
   }
 
-  res
+  # order by the path (which contains the version) and then by modified time.
+  # This needs to be done in case the same package is available from multiple
+  # repositories.
+  res[order(res$path, res$mtime), ]
 }

--- a/tests/testthat/test-install-version.R
+++ b/tests/testthat/test-install-version.R
@@ -15,11 +15,11 @@ test_that("package_find_repo() works correctly with multiple repos", {
 test_that("package_find_repo() works correctly with archived packages", {
   # Issue 1033
 
-  repos <- c(CRAN = "https://cran.rstudio.com")
+  repos <- c(CRAN = "http://cran.rstudio.com")
   package <- "igraph0"
   res <- package_find_repo(package, repos = repos)
 
   expect_gte(NROW(res), 8L)
-  expect_true(all(res$repo == "https://cran.rstudio.com"))
+  expect_true(all(res$repo == "http://cran.rstudio.com"))
   expect_true(all(grepl("^igraph0", res$path)))
 })

--- a/tests/testthat/test-install-version.R
+++ b/tests/testthat/test-install-version.R
@@ -9,5 +9,17 @@ test_that("package_find_repo() works correctly with multiple repos", {
 
   expect_equal(NROW(res), 1L)
   expect_equal(res$repo, "http://cran.rstudio.com")
-  expect_match(rownames(res), package)
+  expect_true(all(grepl("^ROI.plugin.glpk", res$path)))
+})
+
+test_that("package_find_repo() works correctly with archived packages", {
+  # Issue 1033
+
+  repos <- c(CRAN = "https://cran.rstudio.com")
+  package <- "igraph0"
+  res <- package_find_repo(package, repos = repos)
+
+  expect_gte(NROW(res), 8L)
+  expect_true(all(res$repo == "https://cran.rstudio.com"))
+  expect_true(all(grepl("^igraph0", res$path)))
 })


### PR DESCRIPTION
If the package is not available we should install only the last archived
version.

Fixes #1033