### PR TITLE
Fix revdep_check() when git2r is not loaded

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,9 @@
 
 * `use_readme_md()` creates a basic `README.md` template (#1064).
 
+* `revdep_check()` doesn't complain about missing `git2r` package anymore
+  (#1068, @krlmlr).
+
 # devtools 1.10.0
 
 ## New features

--- a/R/build.r
+++ b/R/build.r
@@ -70,13 +70,9 @@ build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
     ext <- ".tar.gz"
   }
 
-  # Create temporary library to ensure that default library doesn't get
+  # Run in temporary library to ensure that default library doesn't get
   # contaminated
-  temp_lib <- tempfile()
-  dir.create(temp_lib)
-  on.exit(unlink(temp_lib, recursive = TRUE), add = TRUE)
-
-  withr::with_libpaths(c(temp_lib, .libPaths()), R(cmd, path, quiet = quiet))
+  withr::with_temp_libpaths(R(cmd, path, quiet = quiet))
   targz <- paste0(pkg$package, "_", pkg$version, ext)
 
   file.path(path, targz)

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -118,10 +118,11 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
     dir.create(srcpath)
 
   message("Installing ", pkg$package, " ", pkg$version, " from ", pkg$path)
-  withr::with_libpaths(libpath, install(pkg, reload = FALSE, quiet = TRUE))
+  withr::with_libpaths(libpath, action = "prefix",
+                       install(pkg, reload = FALSE, quiet = TRUE))
   on.exit(remove.packages(pkg$package, libpath), add = TRUE)
 
-  res <- withr::with_envvar(c(
+  withr::with_envvar(c(
     NOT_CRAN = "false",
     RGL_USE_NULL = "true"
   ), {

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -119,7 +119,7 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
 
   message("Installing ", pkg$package, " ", pkg$version, " from ", pkg$path)
   withr::with_libpaths(libpath, action = "prefix",
-                       install(pkg, reload = FALSE, quiet = TRUE))
+                       install(pkg, reload = FALSE, quiet = TRUE, dependencies = TRUE))
   on.exit(remove.packages(pkg$package, libpath), add = TRUE)
 
   withr::with_envvar(c(


### PR DESCRIPTION
When installing package during revdep check, use new libpath in addition to existing libpath. Reason: if git2r is not loaded yet, an error is raised if it not in the temporary library.