### PR TITLE
Print more detailed error message if given JSON response

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -22,11 +22,12 @@ github_error <- function(req) {
   parsed <- jsonlite::fromJSON(text, simplifyVector = FALSE)
   errors <- vapply(parsed$errors, `[[`, "message", FUN.VALUE = character(1))
 
-  structure(list(
+  structure(
+    list(
       call = sys.call(-1),
       message = paste0(parsed$message, " (", httr::status_code(req), ")\n",
-        paste("* ", errors, collapse = "\n")),
-      class = c("condition", "error", "github_error")))
+        paste("* ", errors, collapse = "\n"))
+    ), class = c("condition", "error", "github_error"))
 }
 
 github_GET <- function(path, ..., pat = github_pat()) {

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -120,7 +120,7 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
     warning("GitHub repo contains submodules, may not function as expected!",
       call. = FALSE)
 
-  download(dest, src, auth)
+  download_github(dest, src, auth)
 }
 
 github_has_remotes <- function(x, auth = NULL) {
@@ -286,4 +286,15 @@ remote_sha.github_remote <- function(remote, url = "https://github.com", ...) {
 
     unname(res[found[1]])
   }, error = function(e) NA)
+}
+
+download_github <- function(path, url, ...) {
+  request <- httr::GET(url, ...)
+
+  if (httr::status_code(request) >= 400) {
+     stop(github_error(request))
+  }
+
+  writeBin(httr::content(request, "raw"), path)
+  path
 }


### PR DESCRIPTION
This takes code from `github_reponse()` to parse the GitHub response information on an error so downloading can give a more informative error message.

If the response does not contain an errors or message component the previous behavior is used.

I could not use `httr::stop_for_status()` directly at https://github.com/hadley/devtools/compare/master...jimhester:download_errors?expand=1#diff-475284c83f91b5f64ec0e4afdbd4c955R135 because the call stack would be uninformative with `sys.call(-1)`.

The following generates the following output after spamming it a bunch of times to produce an error.
```
download("test", "https://github.com/jimhester/withr/archive/1.0.1.tar.gz")
No encoding supplied: defaulting to UTF-8.
Error in download("test", "https://github.com/jimhester/withr/archive/1.0.1.tar.gz") :
  Too Many Requests (RFC 6585) (HTTP 429).
```