### PR TITLE
Use relative path in .Rbuildignore

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -666,7 +666,7 @@ use_template <- function(template, save_as = template, data = list(),
 
   if (ignore) {
     message("* Adding `", save_as, "` to `.Rbuildignore`.")
-    use_build_ignore(path, pkg = pkg)
+    use_build_ignore(save_as, pkg = pkg)
   }
 
   if (open) {


### PR DESCRIPTION
...instead of absolute path; fixes a regression that affects use_build_ignore() and all infrastructure functions that call it.