### PR TITLE
Put Rtools on the path if needed for install_packages

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -280,7 +280,14 @@ install_packages <- function(pkgs, repos = getOption("repos"),
       "Installing %d package: %s",
       "Installing %d packages: %s"
     ), length(pkgs), paste(pkgs, collapse = ", ")))
-  utils::install.packages(pkgs, repos = repos, type = type, ...,
+
+  # if type is 'source' and on windows add Rtools to the path this assumes
+  # setup_rtools() has already run and set the rtools path
+  if (type == "source" && !is.null(get_rtools_path())) {
+    old <- add_path(get_rtools_path(), 0)
+    on.exit(set_path(old))
+  }
+  utils::install.packages(pkgs, repos = repos, type = type,
     dependencies = dependencies, quiet = quiet)
 }
 


### PR DESCRIPTION
We might want to consider always changing `check_build_tools()` to not take a package and call it whenever type = 'source' on windows...

This change assumes `check_build_tools()` has been called in the past and the rtools path has been setup.