### PR TITLE
Add a default GITHUB_PAT if running on a CI service

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -75,7 +75,7 @@ github_pat <- function(quiet = FALSE) {
                   "0a7f1ed",
                   "c485e443")
     if (!quiet) {
-      message("Using bundled GitHub PAT")
+      message("Using bundled GitHub PAT. Please add your own PAT to the env var `GITHUB_PAT`")
     }
     return(pat)
   }

--- a/R/github.R
+++ b/R/github.R
@@ -61,7 +61,7 @@ github_tag <- function(username, repo, ref = "master") {
 #' @keywords internal
 #' @export
 github_pat <- function(quiet = FALSE) {
-  pat <- Sys.getenv('GITHUB_PAT')
+  pat <- Sys.getenv("GITHUB_PAT")
   if (nzchar(pat)) {
     if (!quiet) {
       message("Using GitHub PAT from envvar GITHUB_PAT")

--- a/R/github.R
+++ b/R/github.R
@@ -62,21 +62,24 @@ github_tag <- function(username, repo, ref = "master") {
 #' @export
 github_pat <- function(quiet = FALSE) {
   pat <- Sys.getenv('GITHUB_PAT')
+  if (nzchar(pat)) {
+    if (!quiet) {
+      message("Using GitHub PAT from envvar GITHUB_PAT")
+    }
+    return(pat)
+  }
   if (in_ci()) {
     pat <- paste0("b2b7441d",
                   "aeeb010b",
                   "1df26f1f6",
                   "0a7f1ed",
                   "c485e443")
+    if (!quiet) {
+      message("Using bundled GitHub PAT")
+    }
+    return(pat)
   }
-  if (identical(pat, "")) return(NULL)
-
-
-  if (!quiet) {
-    message("Using github PAT from envvar GITHUB_PAT")
-  }
-
-  pat
+  return(NULL)
 }
 
 in_ci <- function() {

--- a/R/github.R
+++ b/R/github.R
@@ -64,9 +64,21 @@ github_pat <- function(quiet = FALSE) {
   pat <- Sys.getenv('GITHUB_PAT')
   if (identical(pat, "")) return(NULL)
 
+  if (in_ci()) {
+    pat <- paste0("b2b7441d",
+                  "aeeb010b",
+                  "1df26f1f6",
+                  "0a7f1ed",
+                  "c485e443")
+  }
+
   if (!quiet) {
     message("Using github PAT from envvar GITHUB_PAT")
   }
 
   pat
+}
+
+in_ci <- function() {
+  nzchar(Sys.getenv("CI"))
 }

--- a/R/github.R
+++ b/R/github.R
@@ -62,8 +62,6 @@ github_tag <- function(username, repo, ref = "master") {
 #' @export
 github_pat <- function(quiet = FALSE) {
   pat <- Sys.getenv('GITHUB_PAT')
-  if (identical(pat, "")) return(NULL)
-
   if (in_ci()) {
     pat <- paste0("b2b7441d",
                   "aeeb010b",
@@ -71,6 +69,8 @@ github_pat <- function(quiet = FALSE) {
                   "0a7f1ed",
                   "c485e443")
   }
+  if (identical(pat, "")) return(NULL)
+
 
   if (!quiet) {
     message("Using github PAT from envvar GITHUB_PAT")


### PR DESCRIPTION
This will prevent most 403 errors due to rate limiting.

This PAT is from my lintr-bot account (which has access to no repositories) and has no permissions, so all it can do is read publicly available information. So it should be safe to use.