### PR TITLE
Include library paths (and package counts) into session_info() output

### DIFF
--- a/R/session-info.r
+++ b/R/session-info.r
@@ -76,7 +76,7 @@ platform_info <- function() {
     ui <- .Platform$GUI
   }
 
-  libs <- normalizePath(.libPaths())
+  libs <- unique(normalizePath(.libPaths()))
   libs <- sapply(libs, function (x) length(list.files(x)))
   libs <- paste0(names(libs), " (", libs, ")")
 

--- a/R/session-info.r
+++ b/R/session-info.r
@@ -76,9 +76,14 @@ platform_info <- function() {
     ui <- .Platform$GUI
   }
 
+  libs <- normalizePath(.libPaths())
+  libs <- sapply(libs, function (x) length(list.files(x)))
+  libs <- paste0(names(libs), " (", libs, ")")
+
   structure(list(
     version = R.version.string,
     system = version$system,
+    library = libs,
     ui = ui,
     language = Sys.getenv("LANGUAGE", "(EN)"),
     collate = Sys.getlocale("LC_COLLATE"),
@@ -90,7 +95,8 @@ platform_info <- function() {
 
 #' @export
 print.platform_info <- function(x, ...) {
-  df <- data.frame(setting = names(x), value = unlist(x), stringsAsFactors = FALSE)
+  x <- unlist(x)
+  df <- data.frame(setting = names(x), value = x, stringsAsFactors = FALSE)
   print(df, right = FALSE, row.names = FALSE)
 }
 


### PR DESCRIPTION
Hello,

many thanks for this helpful package.

What I favour, is the information about my current `.libPaths()` and the amount of packages inside each folder to be included in a session information.

Thus, I show a solution to include the library paths and their subdirectory numbers into the `platform_info` and its print method. Problems might be artificial folders, but a check with `installed.packages()` or searching for a valid `DESCRIPTION` file might slow down the process.

Output might look like this:

```
Session info -------------------------------------------------------------------------------------------------------------------
 setting  value                                                                      
 version  R version 3.2.3 (2015-12-10)                                               
 system   x86_64, darwin15.3.0                                                       
 library1 /usr/local/lib/R/3.2/site-library (227)                                    
 library2 /usr/local/Cellar/r/3.2.3_1/R.framework/Versions/3.2/Resources/library (30)
 ui       RStudio (0.99.489)                                                         
 language (EN)                                                                       
 collate  en_US.UTF-8                                                                
 tz       Europe/Berlin                                                              
 date     2016-03-22         
[...]                                                        
```

Regards,
Sven