### PR TITLE
release() with detached Git head doesn't throw error

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -29,7 +29,7 @@ git_sync_status <- function(path = ".") {
     return(invisible(FALSE))
   }
 
-  c1 <- git2r::commits(r)[[1]]
+  c1 <- git2r::lookup(r, git2r::branch_target(r_head))
   c2 <- git2r::lookup(r, git2r::branch_target(upstream))
   ab <- git2r::ahead_behind(c1, c2)
 

--- a/R/git.R
+++ b/R/git.R
@@ -17,7 +17,12 @@ git_uncommitted <- function(path = ".") {
 git_sync_status <- function(path = ".") {
   r <- git2r::repository(path, discover = TRUE)
 
-  upstream <- git2r::branch_get_upstream(git2r::head(r))
+  r_head <- git2r::head(r)
+  if (!methods::is(r_head, "git_branch")) {
+    return(invisible(FALSE))
+  }
+
+  upstream <- git2r::branch_get_upstream(r_head)
   # fetch(r, branch_remote_name(upstream))
 
   if (is.null(upstream)) {


### PR DESCRIPTION
@stewid: Can this be done better? I have found is_commit(), but not is_branch().