### PR TITLE
Remove NOTE about improper registration

### DIFF
--- a/R/has-devel.r
+++ b/R/has-devel.r
@@ -1,3 +1,15 @@
+# The checking code looks for the objects in the package namespace, so defining
+# dll here removes the following NOTE
+# Registration problem:
+#   Evaluating ‘dll$foo’ during check gives error
+# ‘object 'dll' not found’:
+#    .C(dll$foo, 0L)
+# See https://github.com/wch/r-source/blob/d4e8fc9832f35f3c63f2201e7a35fbded5b5e14c/src/library/tools/R/QC.R#L1950-L1980
+# Setting the class is needed to avoid a note about returning the wrong class.
+# The local object is found first in the actual call, so current behavior is
+# unchanged.
+dll <- list(foo = structure(list(), class = "NativeSymbolInfo"))
+
 #' Check if you have a development environment installed.
 #'
 #' Thanks to the suggestion of Simon Urbanek.


### PR DESCRIPTION
The comment mostly explains the reasoning and why this works. Basically checkFF calls `try(eval(e, pkg_env))` where `e` is the first argument to `.C()` and `pkg_env` is the package namespace. `dll$foo` was previously not found in the package namespace which is why the NOTE was happening. This is really a false positive so we should be able to turn it off with `dontCheck()`, but CRAN disables that when you set `--as-cran`. So the only way to remove this NOTE is to define an object in the package namespace, which is what this does.