### PR TITLE
Fully qualify attach calls to remove NOTE

### DIFF
--- a/R/package-env.r
+++ b/R/package-env.r
@@ -8,7 +8,7 @@ attach_ns <- function(pkg = ".") {
   }
 
   # This should be similar to attachNamespace
-  pkgenv <- attach(NULL, name = pkg_env_name(pkg))
+  pkgenv <- base::attach(NULL, name = pkg_env_name(pkg))
   attr(pkgenv, "path") <- getNamespaceInfo(nsenv, "path")
 }
 

--- a/R/shims.r
+++ b/R/shims.r
@@ -21,7 +21,7 @@ insert_global_shims <- function() {
   e$`?` <- shim_question
   e$system.file <- shim_system.file
 
-  attach(e, name = "devtools_shims", warn.conflicts = FALSE)
+  base::attach(e, name = "devtools_shims", warn.conflicts = FALSE)
 }
 
 #' Replacement version of system.file


### PR DESCRIPTION
The code looking for attach looks only for `attach` as the first element in a call. Using `base::attach()` invalidates this so no NOTE is returned.

With #1138 devtools is now NOTE free, which should make future submissions a little smoother for us and CRAN.