### PR TITLE
added return(invisible()) in release

### DIFF
--- a/R/release.r
+++ b/R/release.r
@@ -51,18 +51,18 @@ release <- function(pkg = ".", check = TRUE, args = NULL) {
     print(dr_d)
 
     if (yesno("Proceed anyway?"))
-      return()
+      return(invisible())
   }
 
   if (uses_git(pkg$path)) {
     if (git_uncommitted(pkg$path)) {
       if (yesno("Uncommited changes in git. Proceed anyway?"))
-        return()
+        return(invisible())
     }
 
     if (git_sync_status(pkg$path)) {
       if (yesno("Git not synched with remote. Proceed anyway?"))
-        return()
+        return(invisible())
     }
   }
 


### PR DESCRIPTION
Selecting a "no" option at the first few steps returns `NULL` which is printed to the console, unlike in later steps where `release()` returns invisibly. This PR fixes the issue.