### PR TITLE
More informative message when forcing unload

### DIFF
--- a/R/unload.r
+++ b/R/unload.r
@@ -66,7 +66,8 @@ unload <- function(pkg = ".") {
   # because things can be in a weird state.
   if (!is.null(.getNamespace(pkg$package))) {
     message("unloadNamespace(\"", pkg$package,
-      "\") not successful. Forcing unload.")
+      "\") not successful, probably because another loaded package depends on it.",
+      "Forcing unload. If you encounter problems, please restart R.")
     unregister_namespace(pkg$package)
   }
 


### PR DESCRIPTION
A lot of people see this message when installing a package from Github and think there's a bug in the package being loaded and/or don't know what to do about it. This makes the message more informative and tells the user what to do if it starts acting up: restart R.

```
unloadNamespace("shiny") not successful. Forcing unload.
```