### PR TITLE
Only clean def files if they are 'packageName.def'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * `install_*` functions and `update_packages()` refactored to allow updating of
   packages installed using any of the install methods. (@jimhester, #1067)
+* `clean_dll()` Only removes package_name.def files and now operates
+  recursively. (@jimhester, #1175, #1159, #1161)
 
 # devtools 1.11.1
 

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -51,7 +51,7 @@ clean_dll <- function(pkg = ".") {
 
   # Clean out the /src/ directory
   files <- dir(file.path(pkg$path, "src"),
-    pattern = "\\.(o|sl|so|dylib|a|dll|def)$",
+    pattern = sprintf("\\.(o|sl|so|dylib|a|dll)$|(%s\\.def)$", pkg$package),
     full.names = TRUE)
   unlink(files)
 

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -52,7 +52,8 @@ clean_dll <- function(pkg = ".") {
   # Clean out the /src/ directory
   files <- dir(file.path(pkg$path, "src"),
     pattern = sprintf("\\.(o|sl|so|dylib|a|dll)$|(%s\\.def)$", pkg$package),
-    full.names = TRUE)
+    full.names = TRUE,
+    recursive = TRUE)
   unlink(files)
 
   invisible(files)


### PR DESCRIPTION
The clean patterns are originally from R CMD build (https://github.com/wch/r-source/blob/4ba41332b405f29569dad311f36500391fe6f41f/src/library/tools/R/build.R#L406-L433), which @hadley referenced in the original PR (https://github.com/hadley/devtools/pull/137#discussion_r1364386)

The previous behavior was too loose, only def files with the package name should be cleaned.

The same is true for `.a` and `.dll` as well, however @wch thought there may be cases we do need to clean all of them.

Fixes https://github.com/hadley/devtools/issues/1159
cc @jeroenooms 