### PR TITLE
Option to turn off helper loading

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -66,6 +66,7 @@
 #' @param export_all If \code{TRUE} (the default), export all objects.
 #'   If \code{FALSE}, export only the objects that are listed as exports
 #'   in the NAMESPACE file.
+#' @param helpers load \pkg{testthat} test helpers. 
 #' @param quiet if \code{TRUE} suppresses output from this function.
 #' @inheritParams as.package
 #' @keywords programming
@@ -86,7 +87,7 @@
 #' }
 #' @export
 load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
-  export_all = TRUE, quiet = FALSE, create = NA) {
+  export_all = TRUE, helpers=TRUE, quiet = FALSE, create = NA) {
   pkg <- as.package(pkg, create = create)
   check_suggested("roxygen2")
 
@@ -171,7 +172,7 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   export_ns(pkg)
 
   # Source test helpers into package environment
-  if (uses_testthat(pkg)) {
+  if (uses_testthat(pkg) && helpers) {
     testthat::source_test_helpers(find_test_dir(pkg$path), env = pkg_env(pkg))
   }
 

--- a/R/load.r
+++ b/R/load.r
@@ -66,7 +66,7 @@
 #' @param export_all If \code{TRUE} (the default), export all objects.
 #'   If \code{FALSE}, export only the objects that are listed as exports
 #'   in the NAMESPACE file.
-#' @param helpers load \pkg{testthat} test helpers. 
+#' @param helpers if \code{TRUE} loads \pkg{testthat} test helpers.
 #' @param quiet if \code{TRUE} suppresses output from this function.
 #' @inheritParams as.package
 #' @keywords programming

--- a/R/load.r
+++ b/R/load.r
@@ -87,7 +87,7 @@
 #' }
 #' @export
 load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
-  export_all = TRUE, helpers=TRUE, quiet = FALSE, create = NA) {
+  export_all = TRUE, helpers = TRUE, quiet = FALSE, create = NA) {
   pkg <- as.package(pkg, create = create)
   check_suggested("roxygen2")
 

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -25,7 +25,7 @@ This is equivalent to running \code{\link{clean_dll}} before
 If \code{FALSE}, export only the objects that are listed as exports
 in the NAMESPACE file.}
 
-\item{helpers}{load \pkg{testthat} test helpers.}
+\item{helpers}{if \code{TRUE} loads \pkg{testthat} test helpers.}
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
 

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -5,7 +5,7 @@
 \title{Load complete package.}
 \usage{
 load_all(pkg = ".", reset = TRUE, recompile = FALSE, export_all = TRUE,
-  quiet = FALSE, create = NA)
+  helpers = TRUE, quiet = FALSE, create = NA)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -24,6 +24,8 @@ This is equivalent to running \code{\link{clean_dll}} before
 \item{export_all}{If \code{TRUE} (the default), export all objects.
 If \code{FALSE}, export only the objects that are listed as exports
 in the NAMESPACE file.}
+
+\item{helpers}{load \pkg{testthat} test helpers.}
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
 


### PR DESCRIPTION
I'd prefer not to load my testthat helpers with `load_all`.

I set a bunch of options like default number of simulations and progress bars which need to be different between interactive use and testing.

nb: Relevant issue is https://github.com/hadley/devtools/issues/1125
