### PR TITLE
Add ability to choose a file in `source_gist()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * `install_*` functions and `update_packages()` refactored to allow updating of
   packages installed using any of the install methods. (@jimhester, #1067)
+  
+* `source_gist()` gains a `filename` argument to specify a particular file to
+  source from a GitHub gist. (@ateucher, #)
 
 # devtools 1.11.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
   packages installed using any of the install methods. (@jimhester, #1067)
   
 * `source_gist()` gains a `filename` argument to specify a particular file to
-  source from a GitHub gist. (@ateucher, #)
+  source from a GitHub gist. (@ateucher, #1172)
 
 # devtools 1.11.1
 

--- a/R/run-source.r
+++ b/R/run-source.r
@@ -128,17 +128,17 @@ find_gist <- function(id, filename) {
 
   if (!is.null(filename)) {
     if (!is.character(filename) || length(filename) > 1 || !grepl("\\.[rR]$", filename)) {
-      stop("'filename' must be NULL, or a single filename ending in .R")
+      stop("'filename' must be NULL, or a single filename ending in .R/.r")
     }
 
     which <- match(tolower(filename), tolower(names(r_files)))
     if (is.na(which)) {
-      stop("You have speficied a file that is not in this gist")
+      stop("You have speficied a file that is not in this gist.")
     }
 
   } else {
     if (length(r_files) > 1) {
-      warning("Multiple R files in gist, using first. You can specify one using the 'filename' argument.")
+      warning("Multiple R files in gist, using first.")
       which <- 1
     }
   }

--- a/man/source_gist.Rd
+++ b/man/source_gist.Rd
@@ -4,7 +4,7 @@
 \alias{source_gist}
 \title{Run a script on gist}
 \usage{
-source_gist(id, ..., which = NULL, sha1 = NULL, quiet = FALSE)
+source_gist(id, ..., filename = NULL, sha1 = NULL, quiet = FALSE)
 }
 \arguments{
 \item{id}{either full url (character), gist ID (numeric or character of
@@ -12,8 +12,8 @@ numeric).}
 
 \item{...}{other options passed to \code{\link{source}}}
 
-\item{which}{if there is more than one R file in the gist, which one to
-source (filename ending in '.R')? Default \code{NULL} will source only the
+\item{filename}{if there is more than one R file in the gist, which one to
+source (filename ending in '.R')? Default \code{NULL} will source the
 first file.}
 
 \item{sha1}{The SHA-1 hash of the file at the remote URL. This is highly
@@ -45,6 +45,10 @@ source_gist("gist.github.com/hadley/6872663")
 source_gist(6872663, sha1 = "54f1db27e60")
 # Wrong hash will result in error
 source_gist(6872663, sha1 = "54f1db27e61")
+
+#' # You can speficy a particular R file in the gist
+source_gist(6872663, filename = "hi.r")
+source_gist(6872663, filename = "hi.r", sha1 = "54f1db27e60")
 }
 }
 

--- a/man/source_gist.Rd
+++ b/man/source_gist.Rd
@@ -4,14 +4,17 @@
 \alias{source_gist}
 \title{Run a script on gist}
 \usage{
-source_gist(id, ..., sha1 = NULL, quiet = FALSE)
+source_gist(id, ..., which = NULL, sha1 = NULL, quiet = FALSE)
 }
 \arguments{
 \item{id}{either full url (character), gist ID (numeric or character of
-numeric). If a gist ID is specified and the entry has multiple files,
-only the first R file in the gist is sourced.}
+numeric).}
 
 \item{...}{other options passed to \code{\link{source}}}
+
+\item{which}{if there is more than one R file in the gist, which one to
+source (filename ending in '.R')? Default \code{NULL} will source only the
+first file.}
 
 \item{sha1}{The SHA-1 hash of the file at the remote URL. This is highly
 recommend as it prevents you from accidentally running code that's not


### PR DESCRIPTION
This adds an argument `filename` to the `source_gist()` function so that a user can specify a particular file in a gist that has more than one (currently it will source the first .r file in a gist).

e.g.:
```r
source_gist("gist.github.com/ateucher/0689a1460a0ac136d3b69c371de3a57e", filename = "hi.r")
source_gist("gist.github.com/ateucher/0689a1460a0ac136d3b69c371de3a57e", filename = "hello.r")
```