### PR TITLE
Always unload package DLLs before installation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.11.1.9000
 
+* Always unload package DLLs before installation (including devtools) so new
+  DLLs can be copied properly on Windows. (@jimhester)
+
 * `install_*` functions and `update_packages()` refactored to allow updating of
   packages installed using any of the install methods. (@jimhester, #1067)
 

--- a/R/install.r
+++ b/R/install.r
@@ -70,13 +70,6 @@ install <-
   pkg <- as.package(pkg)
   check_build_tools(pkg)
 
-  # Forcing all of the promises for the current namespace now will avoid lazy-load
-  # errors when the new package is installed overtop the old one.
-  # https://stat.ethz.ch/pipermail/r-devel/2015-December/072150.html
-  if (is_loaded(pkg)) {
-    eapply(ns_env(pkg), force, all.names = TRUE)
-  }
-
   root_install <- is.null(installing$packages)
   if (root_install) {
     on.exit(installing$packages <- NULL)
@@ -93,6 +86,14 @@ install <-
   if (!quiet) {
     message("Installing ", pkg$package)
   }
+  # Forcing all of the promises for the current namespace now will avoid lazy-load
+  # errors when the new package is installed overtop the old one.
+  # https://stat.ethz.ch/pipermail/r-devel/2015-December/072150.html
+  if (is_loaded(pkg)) {
+    eapply(ns_env(pkg), force, all.names = TRUE)
+    unload(pkg$path)
+  }
+
 
   # If building vignettes, make sure we have all suggested packages too.
   if (build_vignettes && missing(dependencies)) {

--- a/R/load.r
+++ b/R/load.r
@@ -121,9 +121,6 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
     unload(pkg)
   }
 
-  # Unload dlls
-  unload_dll(pkg)
-
   if (reset) {
     clear_cache()
     if (is_loaded(pkg)) unload(pkg)

--- a/R/namespace-env.r
+++ b/R/namespace-env.r
@@ -345,7 +345,7 @@ register_namespace <- function(name = NULL, env = NULL) {
     stop("Namespace ", name, " is already registered.")
 
   # Add the environment to the registry
-  nsr <- ns_registry()
+  nsr <- ns_registry
   nsr[[name]] <- env
 
   env
@@ -363,6 +363,6 @@ unregister_namespace <- function(name = NULL) {
     stop(name, " is not a registered namespace.")
 
   # Remove the item from the registry
-  do.call(rm, args = list(name, envir = ns_registry()))
+  do.call(rm, args = list(name, envir = ns_registry))
   invisible()
 }

--- a/R/unload.r
+++ b/R/unload.r
@@ -86,14 +86,6 @@ unload_dll <- function(pkg = ".") {
   # finalise
   gc()
 
-  # Special case for devtools - don't unload DLL because we need to be able
-  # to access nsreg() in the DLL in order to run makeNamespace. This means
-  # that changes to compiled code in devtools can't be reloaded with
-  # load_all -- it requires a reinstallation.
-  if (pkg$package == "devtools") {
-    return(invisible())
-  }
-
   pkglibs <- loaded_dlls(pkg)
 
   for (lib in pkglibs) {

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -67,6 +67,7 @@ NULL
   assign("withr_with_dir", withr::with_dir, envir = env)
   assign("withr_with_collate", withr::with_collate, envir = env)
   assign("withr_with_envvar", withr::with_envvar, envir = env)
+  assign("ns_registry", ns_registry(), envir = env)
 
   invisible()
 }


### PR DESCRIPTION
This also finds the namespace registry once onLoad() rather than
dynamically, so the devtools DLL can be unloaded in load_all() without
needing ns_registory() when creating a new namespace.

As far as I am aware the namespace registry environment is only created once per session, so it should remain stable after it is read in .onLoad().

The main impetus for this PR was a comment by @richfitz on slack
> Having been through a bunch of pain with windows users with devtools this month, I would advise going a CRAN/drat/local cran route.  Recent devtools is enthusiastic about upgrading packages which leaves R sessions in unrecoverable positions as curl and devtools get upgraded unsuccessfully due to file locking.

Users could still have issues with prior versions of devtools, but after this newer devtools versions (and other packages) should now upgrade more cleanly on Windows.