### PR TITLE
Install Suggested package after package installation

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -111,9 +111,15 @@ dev_package_deps <- function(pkg = ".", dependencies = NA,
       repos[missing_repos] <- bioc_repos[missing_repos]
   }
 
-  filter_duplicate_deps(
+  res <- filter_duplicate_deps(
     package_deps(deps, repos = repos, type = type),
-    remote_deps(pkg, deps))
+
+    # We set this cache in install() so we can run install_deps() twice without
+    # having to re-query the remotes
+    installing$remote_deps %||% remote_deps(pkg))
+
+  # Only keep dependencies we actually want to use
+  res[res$package %in% deps, ]
 }
 
 filter_duplicate_deps <- function(cran_deps, remote_deps, dependencies) {
@@ -186,7 +192,7 @@ split_remotes <- function(x) {
   trim_ws(unlist(strsplit(x, ",[[:space:]]*")))
 }
 
-remote_deps <- function(pkg, deps) {
+remote_deps <- function(pkg) {
   pkg <- as.package(pkg)
 
   if (!has_dev_remotes(pkg)) {
@@ -213,7 +219,7 @@ remote_deps <- function(pkg, deps) {
     class = c("package_deps", "data.frame"))
   res$remote <- structure(remotes, class = "remotes")
 
-  res[res$package %in% deps, ]
+  res
 }
 
 has_dev_remotes <- function(pkg) {

--- a/R/deps.R
+++ b/R/deps.R
@@ -113,12 +113,13 @@ dev_package_deps <- function(pkg = ".", dependencies = NA,
 
   filter_duplicate_deps(
     package_deps(deps, repos = repos, type = type),
-    remote_deps(pkg))
+    remote_deps(pkg, deps))
 }
 
-filter_duplicate_deps <- function(cran_deps, remote_deps) {
+filter_duplicate_deps <- function(cran_deps, remote_deps, dependencies) {
   deps <- rbind(cran_deps, remote_deps)
 
+  # Only keep the remotes that are specified in the cran_deps
   # Keep only the Non-CRAN remotes if there are duplicates as we want to install
   # the development version rather than the CRAN version. The remotes will
   # always be specified after the CRAN dependencies, so using fromLast will
@@ -185,7 +186,7 @@ split_remotes <- function(x) {
   trim_ws(unlist(strsplit(x, ",[[:space:]]*")))
 }
 
-remote_deps <- function(pkg) {
+remote_deps <- function(pkg, deps) {
   pkg <- as.package(pkg)
 
   if (!has_dev_remotes(pkg)) {
@@ -212,7 +213,7 @@ remote_deps <- function(pkg) {
     class = c("package_deps", "data.frame"))
   res$remote <- structure(remotes, class = "remotes")
 
-  res
+  res[res$package %in% deps, ]
 }
 
 has_dev_remotes <- function(pkg) {

--- a/R/install.r
+++ b/R/install.r
@@ -96,9 +96,15 @@ install <-
 
   # If building vignettes, make sure we have all suggested packages too.
   if (build_vignettes && missing(dependencies)) {
-    dependencies <- TRUE
+    dependencies <- standardise_dep(TRUE)
+  } else {
+    dependencies <- standardise_dep(dependencies)
   }
-  install_deps(pkg, dependencies = dependencies, upgrade = upgrade_dependencies,
+
+  initial_deps <- dependencies[dependencies != "Suggests"]
+  final_deps <- dependencies[dependencies == "Suggests"]
+
+  install_deps(pkg, dependencies = initial_deps, upgrade = upgrade_dependencies,
     threads = threads, force_deps = force_deps, quiet = quiet, ...)
 
   # Build the package. Only build locally if it doesn't have vignettes
@@ -123,6 +129,9 @@ install <-
   built_path <- normalizePath(built_path, winslash = "/")
   R(paste("CMD INSTALL ", shQuote(built_path), " ", opts, sep = ""),
     quiet = quiet)
+
+  install_deps(pkg, dependencies = final_deps, upgrade = upgrade_dependencies,
+    threads = threads, force_deps = force_deps, quiet = quiet, ...)
 
   if (length(metadata) > 0) {
     add_metadata(inst(pkg$package), metadata)

--- a/R/install.r
+++ b/R/install.r
@@ -104,6 +104,11 @@ install <-
   initial_deps <- dependencies[dependencies != "Suggests"]
   final_deps <- dependencies[dependencies == "Suggests"]
 
+  # cache the Remote: dependencies here so we don't have to query them each
+  # time we call install_deps
+  installing$remote_deps <- remote_deps(pkg)
+  on.exit(installing$remote_deps <- NULL, add = TRUE)
+
   install_deps(pkg, dependencies = initial_deps, upgrade = upgrade_dependencies,
     threads = threads, force_deps = force_deps, quiet = quiet, ...)
 
@@ -113,7 +118,7 @@ install <-
     built_path <- pkg$path
   } else {
     built_path <- build(pkg, tempdir(), vignettes = build_vignettes, quiet = quiet)
-    on.exit(unlink(built_path))
+    on.exit(unlink(built_path), add = TRUE)
   }
 
   opts <- c(


### PR DESCRIPTION
This includes packages specified in Remotes:. If build_vignettes is TRUE
they are still installed before the package.

This fixes hadley/dplyr#1809