### PR TITLE
Disable JIT during/at compiler package loading/unloading.

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -92,6 +92,15 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 
   if (!quiet) message("Loading ", pkg$package)
 
+  if (pkg$package == "compiler") {
+    # Disable JIT while loading the compiler package to avoid interference
+    # (otherwise the compiler package would be loaded as a side effect of
+    # JIT compilation and it would be locked before we can insert shims into
+    # it).
+    oldEnabled <- compiler::enableJIT(0)
+    on.exit(compiler::enableJIT(oldEnabled), TRUE)
+  }
+
   roxygen2::update_collate(pkg$path)
   # Refresh the pkg structure with any updates to the Collate entry
   # in the DESCRIPTION file

--- a/R/unload.r
+++ b/R/unload.r
@@ -28,7 +28,20 @@
 #' }
 #' @export
 unload <- function(pkg = ".") {
+
   pkg <- as.package(pkg)
+
+  if (pkg$package == "compiler") {
+    # Disable JIT compilation as it could interfere with the compiler
+    # unloading. Also, if the JIT was kept enabled, it would cause the
+    # compiler package to be loaded again soon, anyway. Note if we
+    # restored the JIT level after the unloading, the call to
+    # enableJIT itself would load the compiler again.
+    oldEnable <- compiler::enableJIT(0)
+    if (oldEnable != 0) {
+      warning("JIT automatically disabled when unloading the compiler.")
+    }
+  }
 
   # This is a hack to work around unloading devtools itself. The unloading
   # process normally makes other devtools functions inaccessible,


### PR DESCRIPTION
This patch is needed to make devtools pass its own tests with the JIT enabled. The patch disables JIT compilation temporarily during loading the compiler namespace (because otherwise the JIT compilation during the loading process interferes, it loads the compiler namespace faster than devtools and locks it before devtools can insert shims into it). The patch also disables JIT (permanently) before unloading the compiler namespace - there seems to be no other way than keeping it disabled, because the call to enable it would immediately load it, which would make the unloading a waste of time. It may not be so important after all to be able to load/unload the compiler package (it should perhaps be loaded at all times anyway), but the devtools unit tests depend on this, and hence the patch.