### PR TITLE
use GitHub tarball API when downloading packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.11.1.9000
 
+* `install_github()` now downloads tarballs rather than zipballs. (@kevinushey)
+
 * Suggested packages, including those specified as `Remotes:` are now installed
   after package installation. This allows you to use circular `Remotes:`
   dependencies for two related packages as long as one of the dependencies is a

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -90,9 +90,9 @@ github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,
 
 #' @export
 remote_download.github_remote <- function(x, quiet = FALSE) {
-  dest <- tempfile(fileext = paste0(".zip"))
+  dest <- tempfile(fileext = paste0(".tar.gz"))
   src_root <- paste0("https://", x$host, "/repos/", x$username, "/", x$repo)
-  src <- paste0(src_root, "/zipball/", x$ref)
+  src <- paste0(src_root, "/tarball/", x$ref)
 
   if (!quiet) {
     message("Downloading GitHub repo ", x$username, "/", x$repo, "@", x$ref,


### PR DESCRIPTION
This PR modifies `install_github` to use the `tarball` endpoint rather than `zipball`.

`devtools` uses its own utility `decompress` function behind the scenes, which farms out to an appropriate decompression utility based on the file extension, so everything should just work here (and appears to in some manual testing)