### PR TITLE
revert change to 'tarball' API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,8 +29,6 @@
 * Add a default codecov.yml file to turn off commenting with `use_coverage()`
   (@jimhester, #1188)
 
-* `install_github()` now downloads tarballs rather than zipballs. (@kevinushey)
-
 * New `install_bioc()` function and bioc remote to install Bioconductor
   packages from their SVN repository.
 

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -90,14 +90,14 @@ github_remote <- function(repo, username = NULL, ref = NULL, subdir = NULL,
 
 #' @export
 remote_download.github_remote <- function(x, quiet = FALSE) {
-  dest <- tempfile(fileext = paste0(".tar.gz"))
+  dest <- tempfile(fileext = paste0(".zip"))
 
   if (missing_protocol <- !grepl("^[^:]+?://", x$host)) {
     x$host <- paste0("https://", x$host)
   }
 
   src_root <- paste0(x$host, "/repos/", x$username, "/", x$repo)
-  src <- paste0(src_root, "/tarball/", x$ref)
+  src <- paste0(src_root, "/zipball/", x$ref)
 
   if (!quiet) {
     message("Downloading GitHub repo ", x$username, "/", x$repo, "@", x$ref,


### PR DESCRIPTION
This PR reverts back to using the zipball API, to resolve https://github.com/hadley/devtools/issues/1217.