### PR TITLE
Added functions to clone git submodules when they are present

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # devtools 1.11.1.9000
 
+* Added a `submodules` option to `install_git` to download the submodules if there
+  is a `.gitmodules` in the repository. Updated the documentation for `install_github()`
+  to reflect this option. (@jonkeane, #1163, #751)
+
 * Handle case when a GitHub request returns a non-JSON error response.
   (@jimhester, #1204, #1211)
 

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -27,7 +27,7 @@
 #' raises a warning. Because the zipped sources provided by GitHub do not
 #' include submodules, this may lead to unexpected behaviour or compilation
 #' failure in source packages. In this case, cloning the repository manually
-#' using \code{\link{install_git}} with \code{args="--recursive"} may yield
+#' using \code{\link{install_git}} with \code{submodules=TRUE} may yield
 #' better results.
 #' @export
 #' @family package installation

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -38,6 +38,13 @@ install_remote <- function(remote, ..., force = FALSE, quiet = FALSE) {
   source <- source_pkg(bundle, subdir = remote$subdir)
   on.exit(unlink(source, recursive = TRUE), add = TRUE)
 
+  # check if there are submodules, download them if there are.
+  if (file.exists(file.path(source, ".gitmodules")) &&
+      inherits(remote, "git_remote") && remote$submodules) {
+    submodules <- read_gitmodules(file.path(source, ".gitmodules"))
+    download_modules(submodules, source=source)
+  }
+
   metadata <- remote_metadata(remote, bundle, source)
 
   install(source, ..., quiet = quiet, metadata = metadata)

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -5,7 +5,7 @@
 \title{Install a package from a git repository}
 \usage{
 install_git(url, subdir = NULL, branch = NULL, credentials = NULL,
-  args = character(0), ...)
+  submodules = FALSE, args = character(0), ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -18,6 +18,8 @@ contain the package we are interested in installing.}
 
 \item{credentials}{A git2r credentials object passed through
 to \code{\link[git2r]{clone}}.}
+
+\item{submodules}{if \code{TRUE} download submodules before installing.}
 
 \item{args}{DEPRECATED. A character vector providing extra arguments to
 pass on to git.}

--- a/man/install_github.Rd
+++ b/man/install_github.Rd
@@ -45,7 +45,7 @@ Attempting to install from a source repository that uses submodules
 raises a warning. Because the zipped sources provided by GitHub do not
 include submodules, this may lead to unexpected behaviour or compilation
 failure in source packages. In this case, cloning the repository manually
-using \code{\link{install_git}} with \code{args="--recursive"} may yield
+using \code{\link{install_git}} with \code{submodules=TRUE} may yield
 better results.
 }
 \examples{

--- a/tests/testthat/test-install-git.R
+++ b/tests/testthat/test-install-git.R
@@ -1,0 +1,29 @@
+context("Install git submodules")
+
+goldStandard <- list(name = "testRepo",
+                     path = "testRepo",
+                     url = "http://github.com/user/testRepo",
+                     branch = NULL)
+
+gitmodule <- '[submodule "testRepo"]
+	path = testRepo
+url = http://github.com/user/testRepo'
+
+test_that("parse_module returns null branch when none is given", {
+  expect_equal(parse_module(gitmodule), goldStandard)
+})
+
+goldStandard <- list(name = "testRepo",
+                     path = "testRepo",
+                     url = "http://github.com/user/testRepo",
+                     branch = "devel")
+
+gitmodule <- '[submodule "testRepo"]
+	path = testRepo
+url = http://github.com/user/testRepo
+branch = devel'
+
+test_that("parse_module returns devel branch when devel is given", {
+  expect_equal(parse_module(gitmodule), goldStandard)
+})
+


### PR DESCRIPTION
`install_git()` now has the option `submodules`. When it is `submodules = TRUE` the submodules that are listed in the `.gitmodules` file are cloned before the package is installed.

There were a number of functions that needed to be added for parsing the `.gitmodule` files, making sure ssh request urls are translated to https request urls. This does not (yet) include the submodule option for `install_github()`. Although I'm happy to add it, if this approach works for the authors. I've written tests for the one function that has no side effects.

This addresses #1163 
