### PR TITLE
Set DESCRIPTION encoding if it is declared

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.11.1.9000
 
+* Bug fix for 'nchar(text) : invalid multibyte string' errors when running
+  `write_dcf()` on DESCRIPTION files with non-ASCII encodings (#1224, @jimhester).
+
 * Handle case when a GitHub request returns a non-JSON error response.
   (@jimhester, #1204, #1211)
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -106,6 +106,12 @@ write_dcf <- function(path, desc) {
   delimiters <- ifelse(starts_with_whitespace, ":", ": ")
   text <- paste0(names(desc), delimiters, desc, collapse = "\n")
 
+  # If the description file has a declared encoding, set it so nchar() works
+  # properly.
+  if ("Encoding" %in% names(desc)) {
+    Encoding(text) <- desc[["Encoding"]]
+  }
+
   if (substr(text, nchar(text), 1) != "\n") {
     text <- paste0(text, "\n")
   }


### PR DESCRIPTION
Fixes 'nchar(text) : invalid multibyte string' Errors