### PR TITLE
Fixes to ensure package2remote respects an updated .libPath()

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -1,5 +1,5 @@
 uses_git <- function(path = ".") {
-  !is.null(git2r::discover_repository(path))
+  !is.null(git2r::discover_repository(path, ceiling = 0))
 }
 
 # sha of most recent commit

--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -124,7 +124,7 @@ remote_sha <- function(remote, ...) UseMethod("remote_sha")
 
 package2remote <- function(name, repos = getOption("repos"), type = getOption("pkgType")) {
 
-  x <- tryCatch(packageDescription(name), error = function(e) NA, warning = function(e) NA)
+  x <- tryCatch(packageDescription(name, lib.loc = .libPaths()), error = function(e) NA, warning = function(e) NA)
 
   # will be NA if not installed
   if (identical(x, NA)) {
@@ -132,7 +132,7 @@ package2remote <- function(name, repos = getOption("repos"), type = getOption("p
         name = name,
         repos = repos,
         pkg_type = type,
-        sha = NA))
+        sha = NA_character_))
   }
 
   if (is.null(x$RemoteType)) {

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -1,12 +1,4 @@
 context("remote_deps")
-with_temp_libpaths <- function(code) {
-  path <- tempfile("temp_libpath")
-  dir.create(path)
-  old <- .libPaths(path)
-  on.exit(.libPaths(old))
-  force(code)
-}
-
 test_that("remote_deps returns NULL if no remotes specified", {
   expect_equal(remote_deps("testTest"), NULL)
 })
@@ -81,4 +73,18 @@ test_that("remote_sha.github_remote returns NA if remote doesn't exist", {
 })
 test_that("remote_sha.github_remote returns expected value if remote does exist", {
   expect_equal(remote_sha(github_remote("hadley/devtools@v1.8.0")), "ad9aac7b9a522354e1ff363a86f389e32cec181b")
+})
+
+test_that("packade2remotes looks for the DESCRIPTION in .libPaths", {
+   expect_equal(package2remote("testTest")$sha, NA_character_)
+   withr::with_temp_libpaths({
+     expect_equal(package2remote("testTest")$sha, NA_character_)
+     install("testTest", quiet = TRUE)
+     expect_equal(package2remote("testTest")$sha, "0.1")
+
+     # Load the namespace, as packageDescription looks in loaded namespaces
+     # first.
+     loadNamespace("testTest")
+    })
+   expect_equal(package2remote("testTest")$sha, NA_character_)
 })

--- a/tests/testthat/test-remotes.r
+++ b/tests/testthat/test-remotes.r
@@ -75,7 +75,7 @@ test_that("remote_sha.github_remote returns expected value if remote does exist"
   expect_equal(remote_sha(github_remote("hadley/devtools@v1.8.0")), "ad9aac7b9a522354e1ff363a86f389e32cec181b")
 })
 
-test_that("packade2remotes looks for the DESCRIPTION in .libPaths", {
+test_that("package2remotes looks for the DESCRIPTION in .libPaths", {
    expect_equal(package2remote("testTest")$sha, NA_character_)
    withr::with_temp_libpaths({
      expect_equal(package2remote("testTest")$sha, NA_character_)


### PR DESCRIPTION
packageDescription() loads the description from the namespace if it is
already loaded, which is not what we want for e.g. revdep_check().

This forces the lookup to be on the current .libPaths() only.

The ceiling parameter in gitr2::discover_repository() is used so that
use_git() only returns true if the input path is the base of the git
repository. This prevents test packages from being considered to be
using git.