### PR TITLE
solution for #1244

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.12.0.9000
 
+* fix auto download method selection for `install_github()` on R 3.1 which
+  lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)
+
 # devtools 1.12.0
 
 ## New features

--- a/R/download-method.R
+++ b/R/download-method.R
@@ -1,4 +1,4 @@
-# Adapated from:
+# Adapted from:
 # https://github.com/rstudio/rstudio/blob/master/src/cpp/session/modules/SessionPackages.R
 #
 # Copyright (C) 2009-12 by RStudio, Inc.
@@ -12,9 +12,9 @@ download_method <- function(x) {
 }
 
 auto_download_method <- function() {
-  if (capabilities("libcurl")) {
+  if (length(capabilities("libcurl")) && capabilities("libcurl")) {
     "libcurl"
-  } else if (capabilities("http/ftp")) {
+  } else if (length(capabilities("http/ftp")) && capabilities("http/ftp")) {
     "internal"
   } else if (nzchar(Sys.which("wget"))) {
     "wget"

--- a/R/download-method.R
+++ b/R/download-method.R
@@ -12,9 +12,9 @@ download_method <- function(x) {
 }
 
 auto_download_method <- function() {
-  if (length(capabilities("libcurl")) && capabilities("libcurl")) {
+  if (isTRUE(capabilities("libcurl"))) {
     "libcurl"
-  } else if (length(capabilities("http/ftp")) && capabilities("http/ftp")) {
+  } else if (isTRUE(capabilities("http/ftp"))) {
     "internal"
   } else if (nzchar(Sys.which("wget"))) {
     "wget"


### PR DESCRIPTION
An option for keeping description correct WRT `install_github()`, especially on R 3.1.

An alternative for those users is:
```R
## method can be one of "curl", "internal", "libcurl" or "wget"
## rather than the default "auto"
options(download.file.method = "curl")
```