### PR TITLE
fix auto_download_method for earlier versions of R

### DIFF
--- a/R/download-method.R
+++ b/R/download-method.R
@@ -12,9 +12,16 @@ download_method <- function(x) {
 }
 
 auto_download_method <- function() {
-  if (capabilities("libcurl")) {
-    "libcurl"
-  } else if (capabilities("http/ftp")) {
+
+  # in R 3.2.0 libcurl capability was added
+  # prior versions of R capabilities does not know about libcurl
+  if (length(capabilities("libcurl")) > 0) {
+    if (capabilities("libcurl")) {
+      return("libcurl")
+    }
+  }
+  
+  if (capabilities("http/ftp")) {
     "internal"
   } else if (nzchar(Sys.which("wget"))) {
     "wget"


### PR DESCRIPTION
Fix for libcurl capabilities() issue in R 3.1

Fix for 
* https://github.com/hadley/devtools/issues/1244
* https://github.com/travis-ci/travis-ci/issues/6218

This would allow devtools to still be dependent on it's current R version and not raised to v3.2.0

Best,
Barret