### PR TITLE
Github URLs may lack trailing `.git`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.12.0.9000
 
+* Parse valid Git remote URLs that lack trailing `.git`, e.g. GitHub browser URLs (#1253, @jennybc).
+
 * Add a `check_bioconductor()` internal function to automatically install
   BiocInstaller() if it is not installed and the user wants to do so.
 

--- a/R/git.R
+++ b/R/git.R
@@ -138,13 +138,14 @@ github_remote_parse <- function(x) {
 
   if (grepl("^(https|git)", x)) {
     # https://github.com/hadley/devtools.git
+    # https://github.com/hadley/devtools
     # git@github.com:hadley/devtools.git
-    re <- "github[^/:]*[/:](.*?)/(.*)\\.git"
+    re <- "github[^/:]*[/:](.*?)/((?:(?!\\.git).)*)(\\.git)?"
   } else {
     stop("Unknown GitHub repo format", call. = FALSE)
   }
 
-  m <- regexec(re, x)
+  m <- regexec(re, x, perl = TRUE)
   match <- regmatches(x, m)[[1]]
   list(
     username = match[2],

--- a/R/git.R
+++ b/R/git.R
@@ -140,12 +140,12 @@ github_remote_parse <- function(x) {
     # https://github.com/hadley/devtools.git
     # https://github.com/hadley/devtools
     # git@github.com:hadley/devtools.git
-    re <- "github[^/:]*[/:](.*?)/((?:(?!\\.git).)*)(\\.git)?"
+    re <- "github[^/:]*[/:]([^/]+)/(.*?)(?:\\.git)?$"
   } else {
     stop("Unknown GitHub repo format", call. = FALSE)
   }
 
-  m <- regexec(re, x, perl = TRUE)
+  m <- regexec(re, x)
   match <- regmatches(x, m)[[1]]
   list(
     username = match[2],

--- a/tests/testthat/test-github-connections.R
+++ b/tests/testthat/test-github-connections.R
@@ -119,3 +119,10 @@ test_that("github_info() prefers, but doesn't require, remote named 'origin'", {
 
 })
 
+test_that("username and repo are extracted from github remote URL", {
+  gh_info <- list(username = "hadley", repo = "devtools",
+                  fullname = "hadley/devtools")
+  expect_identical(github_remote_parse("https://github.com/hadley/devtools.git"), gh_info)
+  expect_identical(github_remote_parse("https://github.com/hadley/devtools"), gh_info)
+  expect_identical(github_remote_parse("git@github.com:hadley/devtools.git"), gh_info)
+})


### PR DESCRIPTION
Apparently Github URLs don't require the trailing `.git`. I verified that you can use the plain browser URL in `git clone` and RStudio _New Project > Version Control ..._ and everything works just fine. Until you call `use_travis()`, `use_coverage()`, etc., where the current regex will fail to extract username and repo. The fact you can push and pull with the browser URL "for services like GitHub" even shows up in the Smart HTTP section of [Pro Git](https://git-scm.com/book/ch4-1.html).
