### PR TITLE
Don't load test helpers twice in test()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
 Suggests:
     curl (>= 0.9),
     crayon,
-    testthat (>= 0.7),
+    testthat (>= 1.0.3),
     BiocInstaller,
     Rcpp (>= 0.10.0),
     MASS,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.12.0.9000
 
+* `test()` doesn't load helpers twice anymre (@krlmlr, #1256).
+
 * fix auto download method selection for `install_github()` on R 3.1 which
   lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)
 

--- a/R/test.r
+++ b/R/test.r
@@ -53,7 +53,7 @@ test <- function(pkg = ".", filter = NULL, ...) {
   Sys.sleep(0.05); utils::flush.console() # Avoid misordered output in RStudio
 
   env <- new.env(parent = ns_env)
-  withr::with_envvar(r_env_vars(), testthat::test_dir(test_path, filter = filter, env = env, ...))
+  withr::with_envvar(r_env_vars(), testthat::test_dir(test_path, filter = filter, env = env, ..., load_helpers = FALSE))
 }
 
 find_test_dir <- function(path) {


### PR DESCRIPTION
requires testthat >= 1.0.3 (hadley/testthat#505).