### PR TITLE
install_version() with multiple repositories

### DIFF
--- a/R/install-version.r
+++ b/R/install-version.r
@@ -49,6 +49,12 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
     all(result)
   }
 
+  ## returns TRUE if 'pkg' is already installed and satisfies all version criteria 'criteria'
+  have <- function(pkg, criteria) {
+    v <- suppressWarnings(packageDescription(pkg, fields = "Version"))
+    !is.na(v) && satisfies(v, criteria)
+  }
+
   install_version_deps <- function(deps) {
     ## TODO How to exclude 'base', 'stats', etc.?
     for (dep in unique(deps$package)) {
@@ -56,12 +62,6 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
       if (!have(dep, lines))
         install_version(dep, paste(lines$compare, lines$version), repos, type, ...)
     }
-  }
-
-  have <- function(pkg, criteria) {
-    v <- suppressWarnings(packageDescription(pkg, fields = "Version"))
-    if (is.na(v)) return(FALSE)
-    satisfies(v, criteria)
   }
 
   numeric_ver <- .standard_regexps()$valid_numeric_version

--- a/R/install-version.r
+++ b/R/install-version.r
@@ -15,6 +15,10 @@
 #' @inheritParams utils::install.packages
 #' @author Jeremy Stephens
 install_version <- function(package, version = NULL, repos = getOption("repos"), type = getOption("pkgType"), ...) {
+  if (length(package) < 1) return()
+  if (length(package) > 1)
+    stop("install_version() must be called with a single 'package' argument - multiple packages given")
+
   numeric_ver <- .standard_regexps()$valid_numeric_version
   package_ver <- .standard_regexps()$valid_package_version
 

--- a/R/install-version.r
+++ b/R/install-version.r
@@ -57,7 +57,7 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
 
   ## TODO should we do for(r in repos) { for (t in c('published','archive')) {...}}, or
   ## for (t in c('published','archive')) { for(r in repos) {...}} ? Right now it's the latter.  It
-  ## only comes up if required version is satisfied by both an early repo in archive/ and a late repo
+  ## only matters if required version is satisfied by both an early repo in archive/ and a late repo
 
   ## First search for currently-published package
   for (repo in repos) {

--- a/R/install-version.r
+++ b/R/install-version.r
@@ -19,16 +19,6 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
   if (length(package) > 1)
     stop("install_version() must be called with a single 'package' argument - multiple packages given")
 
-  numeric_ver <- .standard_regexps()$valid_numeric_version
-  package_ver <- .standard_regexps()$valid_package_version
-
-  spec <- if(is.null(version) || is.na(version)) package else
-    ifelse(grepl(paste0("^", numeric_ver, "$"), version),
-           paste0(package, "(== ", version, ")"),
-           paste0(package, "(", version, ")"))
-
-  required <- parse_deps(paste(spec, collapse=", "))
-
   ## returns TRUE if version 'to.check' satisfies version criteria 'criteria'
   satisfies <- function(to.check, criteria) {
     to.check <- package_version(to.check)
@@ -53,6 +43,16 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
     if (is.na(v)) return(FALSE)
     satisfies(v, criteria)
   }
+
+  numeric_ver <- .standard_regexps()$valid_numeric_version
+  package_ver <- .standard_regexps()$valid_package_version
+
+  spec <- if(is.null(version) || is.na(version)) package else
+    ifelse(grepl(paste0("^", numeric_ver, "$"), version),
+           paste0(package, "(== ", version, ")"),
+           paste0(package, "(", version, ")"))
+
+  required <- parse_deps(paste(spec, collapse=", "))
 
 
   ## TODO should we do for(r in repos) { for (t in c('published','archive')) {...}}, or

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -2,23 +2,23 @@
 % Please edit documentation in R/install-version.r
 \name{install_version}
 \alias{install_version}
-\title{Install specified version of a CRAN package.}
+\title{Install specific version of a package.}
 \usage{
 install_version(package, version = NULL, repos = getOption("repos"),
   type = getOption("pkgType"), ...)
 }
 \arguments{
-\item{package}{package name}
+\item{package}{Name of the package to install.}
 
-\item{version}{If the specified version is NULL or the same as the most
-recent version of the package, this function simply calls
-\code{\link{install}}. Otherwise, it looks at the list of
-archived source tarballs and tries to install an older version instead.}
+\item{version}{Version of the package to install.  Can either be a string giving the exact
+version required, or a specification in the same format as the parenthesized expressions used
+in package dependencies (see \code{\link{parse_deps}} and/or
+\url{https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Package-Dependencies}).}
 
 \item{repos}{
     character vector, the base URL(s) of the repositories
     to use, e.g., the URL of a CRAN mirror such as
-    \code{"http://cran.us.r-project.org"}.  For more details on
+    \code{"https://cloud.r-project.org"}.  For more details on
     supported URL schemes see \code{\link{url}}.
 
     Can be \code{NULL} to install from local files, directories or URLs:
@@ -26,19 +26,41 @@ archived source tarballs and tries to install an older version instead.}
   }
 
 \item{type}{character, indicating the type of package to download and
-    install.  Will be \code{"source"} except on Windows and some OS X
+    install.  Will be \code{"source"} except on Windows and some macOS
     builds: see the section on \sQuote{Binary packages} for those.
   }
 
 \item{...}{Other arguments passed on to \code{\link{install}}.}
 }
 \description{
-If you are installing an package that contains compiled code, you will
-need to have an R development environment installed.  You can check
-if you do by running \code{\link[pkgbuild]{has_build_tools}}.
+This function knows how to look in multiple CRAN-like package repositories, and in their
+\code{archive} directories, in order to find specific versions of the requested package.
+}
+\details{
+The repositories are searched in the order specified by the \code{repos} argument.  This enables
+teams to maintain multiple in-house repositories with different policies - for instance, one repo
+for development snapshots and one for official releases.  A common setup would be to first search
+the official release repo, then the dev snapshot repo, then a public CRAN mirror.
+
+Older versions of packages on CRAN are usually only available in source form.  If your requested
+package contains compiled code, you will need to have an R development environment installed. You
+can check if you do by running \code{\link[pkgbuild]{has_devel}}.
+}
+\examples{
+\dontrun{
+install_version('devtools', '1.11.0')
+install_version('devtools', '>= 1.12.0')
+
+## Specify search order (e.g. in ~/.Rprofile)
+options(repos=c(prod = 'http://mycompany.example.com/r-repo',
+                dev  = 'http://mycompany.example.com/r-repo-dev',
+                CRAN = 'https://cran.revolutionanalytics.com'))
+install_version('mypackage', '1.15')        # finds in 'prod'
+install_version('mypackage', '1.16-39487')  # finds in 'dev'
+}
 }
 \author{
-Jeremy Stephens
+Jeremy Stephens and Ken Williams
 }
 \seealso{
 Other package installation: \code{\link{install_bioc}},


### PR DESCRIPTION
Following up on my previous ticket #1107, this PR adds the ability for `install_version()` to search multiple CRAN[-like] repositories for a specific version of a package.  Currently, if it finds a package in an early repository but it's not the requested version, it will fail - this PR lets it continue searching the next repositories.

From the new docs I wrote for it:

> This function knows how to look in multiple CRAN-like package repositories, and in their \code{archive} directories, in order to find specific versions of the requested package.
> 
> The repositories are searched in the order specified by the \code{repos} argument.  This enables teams to maintain multiple in-house repositories with different policies - for instance, one repo for development snapshots and one for official releases.  A common setup would be to first search the official release repo, then the dev snapshot repo, then a public CRAN mirror.

Thanks.
