### PR TITLE
Allow update_packages() prompt to be overridden

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.12.0.9000
 
+* `update_packages()` allows for override of interactive prompt (#1260, @pkq).
+
 * Bugfix for installation of dependencies of dependencies (@jimhester, #1409).
 
 * `RCMD()`, `clean_source()`, `eval_clean()` and `evalq_clean()` have been

--- a/R/deps.R
+++ b/R/deps.R
@@ -364,8 +364,9 @@ standardise_dep <- function(x) {
 #' Works similarly to \code{install.packages()} but doesn't install packages
 #' that are already installed, and also upgrades out dated dependencies.
 #'
-#' @param pkgs Character vector of packages to update. If \code{NULL} all
-#'   installed packages are updated.
+#' @param pkgs Character vector of packages to update. IF \code{TRUE} all
+#'   installed packages are updated. If \code{NULL} user is prompted to
+#'   confirm update of all installed packages.
 #' @inheritParams package_deps
 #' @seealso \code{\link{package_deps}} to see which packages are out of date/
 #'   missing.
@@ -379,7 +380,10 @@ update_packages <- function(pkgs = NULL, dependencies = NA,
                             repos = getOption("repos"),
                             type = getOption("pkgType")) {
 
-  if (is.null(pkgs)) {
+  if (isTRUE(pkgs)) {
+    pkgs <- installed.packages()[, "Package"]
+  }
+  else if (is.null(pkgs)) {
     if (!yesno("Are you sure you want to update all installed packages?")) {
       pkgs <- installed.packages()[, "Package"]
     } else {

--- a/man/update_packages.Rd
+++ b/man/update_packages.Rd
@@ -8,8 +8,9 @@ update_packages(pkgs = NULL, dependencies = NA,
   repos = getOption("repos"), type = getOption("pkgType"))
 }
 \arguments{
-\item{pkgs}{Character vector of packages to update. If \code{NULL} all
-installed packages are updated.}
+\item{pkgs}{Character vector of packages to update. IF \code{TRUE} all
+installed packages are updated. If \code{NULL} user is prompted to
+confirm update of all installed packages.}
 
 \item{dependencies}{Which dependencies do you want to check?
   Can be a character vector (selecting from "Depends", "Imports",
@@ -38,4 +39,3 @@ update_packages(c("plyr", "ggplot2"))
 \code{\link{package_deps}} to see which packages are out of date/
   missing.
 }
-


### PR DESCRIPTION
Following up on ticket #1260, this PR adds the ability to use `update_packages()` non-interactively by adding an `override` argument (i.e., `override = TRUE`). Currently, `calling update_packages()` without a list of packages prompts the user to confirm the updates - this PR allows the user to override this prompt.

FYI, I did read [guidelines for contributing](https://github.com/hadley/devtools/blob/master/CONTRIBUTING.md), as requested, but wasn't sure how or where to add a test for this.

Thanks.
