### PR TITLE
using authenticate to access Github package name. fixes #1262

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -214,9 +214,9 @@ remote_deps <- function(pkg) {
   dev_packages <- split_remotes(pkg[["remotes"]])
   remote <- lapply(dev_packages, parse_one_remote)
 
-  package <- vapply(remote, remote_package_name, character(1))
-  installed <- vapply(package, local_sha, character(1))
-  available <- vapply(remote, remote_sha, character(1))
+  package <- vapply(remote, remote_package_name, character(1), USE.NAMES = FALSE)
+  installed <- vapply(package, local_sha, character(1), USE.NAMES = FALSE)
+  available <- vapply(remote, remote_sha, character(1), USE.NAMES = FALSE)
   diff <- installed == available
   diff <- ifelse(!is.na(diff) & diff, CURRENT, BEHIND)
 

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -243,18 +243,27 @@ parse_git_repo <- function(path) {
 }
 
 #' @export
-remote_package_name.github_remote <- function(remote, url = "https://github.com", ...) {
+remote_package_name.github_remote <- function(remote, url = "https://raw.githubusercontent.com", ...) {
 
   tmp <- tempfile()
   path <- paste(c(
       remote$username,
       remote$repo,
-      "raw",
       remote$ref,
       remote$subdir,
       "DESCRIPTION"), collapse = "/")
 
-  req <- httr::GET(url, path = path, httr::write_disk(path = tmp))
+  if (!is.null(remote$auth_token)) {
+    auth <- httr::authenticate(
+      user = remote$auth_token,
+      password = "x-oauth-basic",
+      type = "basic"
+    )
+  } else {
+    auth <- NULL
+  }
+
+  req <- httr::GET(url, path = path, httr::write_disk(path = tmp), auth)
 
   if (httr::status_code(req) >= 400) {
     return(NA_character_)
@@ -302,3 +311,4 @@ download_github <- function(path, url, ...) {
   writeBin(httr::content(request, "raw"), path)
   path
 }
+

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -311,4 +311,3 @@ download_github <- function(path, url, ...) {
   writeBin(httr::content(request, "raw"), path)
   path
 }
-


### PR DESCRIPTION
The new version of devtools is unable to resolve remote package names for private github repositories.

Used same approach as in `remote_download.github_remote` for
authenticating, and changed the url used from
https://github.com/user/repo/RAW/... to
https://raw.githubusercontent.com/user/repo/...

This should fix #1262 
