### PR TITLE
fix install_git to allow installing from a specific tag

### DIFF
--- a/R/install-git.r
+++ b/R/install-git.r
@@ -51,7 +51,13 @@ remote_download.git_remote <- function(x, quiet = FALSE) {
 
   if (!is.null(x$branch)) {
     r <- git2r::repository(bundle)
-    git2r::checkout(r, x$branch)
+
+    if(x$branch %in% names(git2r::tags(r))) {
+      git2r::checkout(git2r::tags(r)[[x$branch]])
+    } else {
+      git2r::checkout(r, x$branch)
+    }
+
   }
 
   bundle


### PR DESCRIPTION
I think install_git does not allow installing from a tag as mentioned in the help. I saw a discussion about this in issue #879; maybe this will work.
