### PR TITLE
Avoid unnecessary query of available_packages()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,13 @@
 # devtools 1.12.0.9000
 
+* `install(dependencies = FALSE)` doesn't query the available packages anymore (@krlmlr, #1269).
+
 * `use_travis()` now opens a webpage in your browser to more easily activate
   a repo.
 
 * `use_readme_rmd()` and `use_readme()` share a common template with sections for package overview, GitHub installation (if applicable), and an example (@jennybc, #1287).
 
-* `test()` doesn't load helpers twice anymre (@krlmlr, #1256).
+* `test()` doesn't load helpers twice anymore (@krlmlr, #1256).
 
 * fix auto download method selection for `install_github()` on R 3.1 which
   lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)

--- a/R/deps.R
+++ b/R/deps.R
@@ -55,12 +55,14 @@ package_deps <- function(pkg, dependencies = NA, repos = getOption("repos"),
     repos <- character()
 
   repos[repos == "@CRAN@"] <- cran_mirror()
-  cran <- available_packages(repos, type)
 
   if (missing(pkg)) {
     pkg <- as.package(".")$package
   }
-  deps <- sort(find_deps(pkg, cran, top_dep = dependencies))
+
+  # It is important to not extract available_packages() to a variable,
+  # for the case when pkg is empty (e.g., install(dependencies = FALSE) ).
+  deps <- sort(find_deps(pkg, available_packages(repos, type), top_dep = dependencies))
 
   # Remove base packages
   inst <- installed.packages()

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,0 +1,11 @@
+context("Install")
+
+test_that("install(dependencies = FALSE) doesn't query available_packages()", {
+  withr::with_temp_libpaths(
+    with_mock(
+      available_packages = function(...) stop("available_packages() called"),
+      expect_error(install("testNamespace", quiet = TRUE), "available_packages"),
+      expect_error(install("testNamespace", quiet = TRUE, dependencies = FALSE), NA)
+    )
+  )
+})


### PR DESCRIPTION
e.g. in `devtools::install(dependencies = FALSE)`

With test.

NEWS entry:

```
* Package installation doesn't query `available_packages()` unless needed, this
  speeds up installation in some scenarios (#1269, @krlmlr).
```