### PR TITLE
Add branch name to install message in install_git

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.12.0.9000
 
+* `install_git()` also prints the branch name (@rubak).
+
 * `test()` doesn't load helpers twice anymre (@krlmlr, #1256).
 
 * fix auto download method selection for `install_github()` on R 3.1 which

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -50,6 +50,9 @@ remote_download.git_remote <- function(x, quiet = FALSE) {
   git2r::clone(x$url, bundle, credentials=x$credentials, progress = FALSE)
 
   if (!is.null(x$branch)) {
+    if (!quiet) {
+    message("Checking out branch ", x$branch)
+    }
     r <- git2r::repository(bundle)
     git2r::checkout(r, x$branch)
   }


### PR DESCRIPTION
Output the name of the branch installed by `install_git()` to the user which may be helpful when browsing back through log.
