### PR TITLE
Revdep e-mail improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # devtools 1.12.0.9000
 
+* Automated revdep check e-mails now can use the new `my_version` and
+  `you_cant_install` variables. The e-mail template has been updated
+  to use these variables (#1285, @krlmlr).
+
 * Various minor improvements around checking of reverse dependencies
   (#1284, @krlmlr). All packages involved are listed at the start,
   the whole process is now more resilient against package

--- a/R/revdep-email.R
+++ b/R/revdep-email.R
@@ -62,7 +62,7 @@ revdep_email <- function(pkg = ".", date,
     author = author)
   bodies <- lapply(data, whisker::whisker.render, template = template)
   subjects <- lapply(data, function(x) {
-    paste0(x$your_package, " and " , x$my_package, " release")
+    paste0(x$your_package, " and " , x$my_package, " ", x$my_version, " release")
   })
 
   emails <- Map(maintainer_email, maintainers, bodies, subjects)
@@ -120,6 +120,7 @@ maintainer_data <- function(result, pkg, gh, date, author) {
     me = author,
     date = date,
     my_package = pkg$package,
+    my_version = pkg$version,
     my_github = gh$fullname
   )
 }

--- a/R/revdep-email.R
+++ b/R/revdep-email.R
@@ -5,6 +5,8 @@
 #'
 #' @inheritParams revdep_check
 #' @param date Date package will be submitted to CRAN
+#' @param version Version which will be used for the CRAN submission (usually
+#'   different from the current package version)
 #' @param author Name used to sign email
 #' @param draft If \code{TRUE}, creates as draft email; if \code{FALSE},
 #'   sends immediately.
@@ -14,6 +16,7 @@
 #' @keywords internal
 #' @export
 revdep_email <- function(pkg = ".", date,
+                         version,
                          author = getOption("devtools.name"),
                          draft = TRUE,
                          unsent = NULL,
@@ -22,6 +25,8 @@ revdep_email <- function(pkg = ".", date,
 
   pkg <- as.package(pkg)
   force(date)
+  force(version)
+
   if (is.null(author)) {
     stop("Please supply `author`", call. = FALSE)
   }
@@ -58,8 +63,8 @@ revdep_email <- function(pkg = ".", date,
   }
 
   gh <- github_info(pkg$path)
-  data <- lapply(results, maintainer_data, pkg = pkg, gh = gh, date = date,
-    author = author)
+  data <- lapply(results, maintainer_data, pkg = pkg, version = version,
+                 gh = gh, date = date, author = author)
   bodies <- lapply(data, whisker::whisker.render, template = template)
   subjects <- lapply(data, function(x) {
     paste0(x$your_package, " and " , x$my_package, " ", x$my_version, " release")
@@ -105,7 +110,7 @@ send_email <- function(email, draft = TRUE) {
   )
 }
 
-maintainer_data <- function(result, pkg, gh, date, author) {
+maintainer_data <- function(result, pkg, version, gh, date, author) {
   problems <- result$results
 
   summary <- indent(paste(trunc_middle(unlist(problems)), collapse = "\n\n"))
@@ -121,7 +126,7 @@ maintainer_data <- function(result, pkg, gh, date, author) {
     me = author,
     date = date,
     my_package = pkg$package,
-    my_version = pkg$version,
+    my_version = version,
     my_github = gh$fullname
   )
 }

--- a/R/revdep-email.R
+++ b/R/revdep-email.R
@@ -116,6 +116,7 @@ maintainer_data <- function(result, pkg, gh, date, author) {
     your_results = summary,
 
     you_have_problems = length(unlist(problems)) > 0,
+    you_cant_install = any(grepl("Rcheck/00install[.]out", problems$errors)),
 
     me = author,
     date = date,

--- a/R/revdep-email.R
+++ b/R/revdep-email.R
@@ -21,7 +21,7 @@ revdep_email <- function(pkg = ".", date,
                          draft = TRUE,
                          unsent = NULL,
                          template = "revdep/email.md",
-                         only_problems = FALSE) {
+                         only_problems = TRUE) {
 
   pkg <- as.package(pkg)
   force(date)

--- a/man/revdep_email.Rd
+++ b/man/revdep_email.Rd
@@ -6,7 +6,7 @@
 \usage{
 revdep_email(pkg = ".", date, version, author = getOption("devtools.name"),
   draft = TRUE, unsent = NULL, template = "revdep/email.md",
-  only_problems = FALSE)
+  only_problems = TRUE)
 }
 \arguments{
 \item{pkg}{Path to package. Defaults to current directory.}

--- a/man/revdep_email.Rd
+++ b/man/revdep_email.Rd
@@ -4,7 +4,7 @@
 \alias{revdep_email}
 \title{Experimental email notification system.}
 \usage{
-revdep_email(pkg = ".", date, author = getOption("devtools.name"),
+revdep_email(pkg = ".", date, version, author = getOption("devtools.name"),
   draft = TRUE, unsent = NULL, template = "revdep/email.md",
   only_problems = FALSE)
 }
@@ -12,6 +12,9 @@ revdep_email(pkg = ".", date, author = getOption("devtools.name"),
 \item{pkg}{Path to package. Defaults to current directory.}
 
 \item{date}{Date package will be submitted to CRAN}
+
+\item{version}{Version which will be used for the CRAN submission (usually
+different from the current package version)}
 
 \item{author}{Name used to sign email}
 

--- a/revdep/email.md
+++ b/revdep/email.md
@@ -1,17 +1,20 @@
 Hi,
 
-This is an automated email to let you know about the upcoming release of {{{ my_package }}}, which will be submitted to CRAN on __{{{ date }}}__. 
+This is an automated email to let you know about the upcoming release of {{{my_package}}} version {{{my_version}}}, which will be submitted to CRAN on __{{{date}}}__. 
 
-To check for potential problems, I ran `R CMD check` on your package {{{your_package}}} ({{{your_version}}}). I found {{{your_summary}}}.
+To check for potential problems, I ran `R CMD check` on your package {{{your_package}}} (version {{{your_version}}}). I found {{{your_summary}}}.
 
 {{#you_have_problems}}
 {{{your_results}}}
 
-Please submit an update to fix any ERRORs or WARNINGs. They may not be caused by the update to {{{my_package}}}, but it really makes life easier if you also fix any other problems that may have accumulated over time. Please also try to minimise the NOTEs. It's not essential you do this, but the fewer the false positives the more likely I am to detect a real problem with your package. 
+{{#you_cant_install}}Looks like I couldn't install your package {{{your_package}}}, I'd recommend you check it yourself. Unfortunately I don't have the resources to manually fix installation failures.
 
-(If I couldn't install your package, I'd recommend you check it yourself. Unfortunately I don't have the resources to manually fix installation failures.)
+{{/you_cant_install}}
+{{^you_cant_install}}Please submit an update of your package {{{your_package}}} to fix any ERRORs or WARNINGs. They may not be caused by the update to {{{my_package}}}, but it really makes life easier if you also fix any other problems that may have accumulated over time. Please also try to minimise the NOTEs. It's not essential you do this, but the fewer the false positives the more likely I am to detect a real problem with your package.
 
-To get the development version of {{{ my_package }}} so you can run the checks yourself, you can run:
+{{/you_cant_install}}
+
+To get the development version of {{{my_package}}} so you can run the checks yourself, you can run:
 
     # install.packages("devtools")
     devtools::install_github("{{my_github}}")
@@ -19,8 +22,8 @@ To get the development version of {{{ my_package }}} so you can run the checks y
 To see what's changed visit <https://github.com/{{{my_github}}}/blob/master/NEWS.md>.
 
 {{/you_have_problems}}
-{{^you_have_problems}}
-It looks like everything is ok, so you don't need to take any action, but you might want to read the NEWS, <https://github.com/{{{my_github}}}/blob/master/NEWS.md>, to see what's changed.
+{{^you_have_problems}}It looks like everything is ok, so you don't need to take any action, but you might want to read the NEWS, <https://github.com/{{{my_github}}}/blob/master/NEWS.md>, to see what's changed.
+
 {{/you_have_problems}}
 
 If you have any questions about this email, please feel free to respond directly.


### PR DESCRIPTION
- new variables `my_version` and `you_cant_install`
- updated e-mail template, tested with the current DBI revdep check results

NEWS entry:

```
* Automated revdep check e-mails now can use the new `my_version` and
  `you_cant_install` variables. The e-mail template has been updated
  to use these variables (#1285, @krlmlr).
```