### PR TITLE
Add cache setting to AppVeyor template

### DIFF
--- a/inst/templates/appveyor.yml
+++ b/inst/templates/appveyor.yml
@@ -10,6 +10,9 @@ init:
 install:
   ps: Bootstrap
 
+cache:
+  - C:\RLibrary
+
 # Adapt as necessary starting from here
 
 build_script:


### PR DESCRIPTION
Seems to work well, e.g., https://ci.appveyor.com/project/krlmlr/r-appveyor/build/1.0.1125/job/jko81yk3uu3blhgc#L12

Reference: https://github.com/krlmlr/r-appveyor/issues/31#issuecomment-203390516

NEWS entry:

```
* Caching is enabled by default in the AppVeyor template created by
  `use_appveyor()` (#1290, @krlmlr).
```