### PR TITLE
Avoid trying to move vignette sources twice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,8 +67,10 @@
 
 * `test()` doesn't load helpers twice anymore (@krlmlr, #1256).
 
-* fix auto download method selection for `install_github()` on R 3.1 which
+* Fix auto download method selection for `install_github()` on R 3.1 which
   lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)
+
+* Fix removal of vignette files by not trying to remove files twice anymore (#1291)
 
 # devtools 1.12.0
 

--- a/R/vignette-r.r
+++ b/R/vignette-r.r
@@ -27,7 +27,7 @@ copy_vignettes <- function(pkg) {
   vigns <- tools::pkgVignettes(dir = pkg$path, output = TRUE, source = TRUE)
   if (length(vigns$docs) == 0) return(invisible())
 
-  out_mv <- c(vigns$outputs, unlist(vigns$sources, use.names = FALSE))
+  out_mv <- c(vigns$outputs, unique(unlist(vigns$sources, use.names = FALSE)))
   out_cp <- vigns$docs
 
   message("Moving ", paste(basename(out_mv), collapse = ", "), " to inst/doc/")


### PR DESCRIPTION
Sometimes multiple vignettes can share source files. This breaks the `file.remove` call which expects unique arguments.

---

the way i encountered this is that `tools::pkgVignettes` has two bugs:
1. it loops over all vignette engines (`tools::loadVignetteBuilder` results in a hardcoding sweave as last engine) and sets `engine` to the last one looped (=always sweave)
2. `tools:::find_vignette_product` is called with that engine and finds _all_ r scripts in the directory prefixed with that name.

this results in duplicated source entries if a vignette’s file name is a prefix of another.
