### PR TITLE
Capture installation output and avoid repeated installation attempts for revdep checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # devtools 1.12.0.9000
 
+* Installation failures are logged during revdep checking, by default in
+  `revdep/install`. Once an installation has failed, it is not attempted
+  a second time (#1300, @krlmlr).
+
 * Various minor improvements around checking of reverse dependencies
   (#1284, @krlmlr). All packages involved are listed at the start,
   the whole process is now more resilient against package

--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -19,7 +19,8 @@
 #'   to the same type as \code{\link{install.packages}()}.
 #' @param threads Number of concurrent threads to use for checking.
 #'   It defaults to the option \code{"Ncpus"} or \code{1} if unset.
-#' @param check_dir Directory to store results.
+#' @param check_dir,install_dir Directory to store check and installation
+#'   results.
 #' @return Returns (invisibly) the directory where check results are stored.
 #' @keywords internal
 #' @inheritParams check
@@ -29,6 +30,7 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
                        type = getOption("pkgType"),
                        threads = getOption("Ncpus", 1),
                        check_dir = tempfile("check_cran"),
+                       install_dir = tempfile("check_cran_install"),
                        env_vars = NULL) {
 
   stopifnot(is.character(pkgs))
@@ -59,7 +61,10 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
     message("Determining packages to update... ", appendLF = FALSE) # ------------
     deps <- package_deps(pkgs, repos = repos, type = type, dependencies = TRUE)
     message(paste(deps$package, collapse = ", "))
-    update(deps, Ncpus = threads, quiet = TRUE)
+
+    dir.create(install_dir, showWarnings = FALSE, recursive = TRUE)
+    update(deps, Ncpus = threads, quiet = FALSE,
+           out_dir = install_dir, skip_if_log_exists = TRUE)
 
     message("Downloading source packages for checking") #-------------------------
     urls <- lapply(pkgs, package_url, repos = repos, available = available_src)

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -118,7 +118,8 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
                          type = getOption("pkgType"),
                          threads = getOption("Ncpus", 1),
                          env_vars = NULL,
-                         check_dir = NULL) {
+                         check_dir = NULL,
+                         install_dir = NULL) {
 
   pkg <- as.package(pkg)
 
@@ -145,6 +146,11 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
       call. = FALSE)
   }
 
+  if (is.null(install_dir)) {
+    install_dir <- file.path(pkg$path, "revdep", "install")
+    message("Saving install results in `revdep/install/`")
+  }
+
   message("Computing reverse dependencies... ", appendLF = FALSE)
   revdeps <- revdep(pkg$package, recursive = recursive, ignore = ignore,
     bioconductor = bioconductor, dependencies = dependencies)
@@ -160,6 +166,7 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
     type = type,
     threads = threads,
     check_dir = check_dir,
+    install_dir = install_dir,
     env_vars = env_vars
   )
   saveRDS(cache, revdep_cache_path(pkg))

--- a/man/check_cran.Rd
+++ b/man/check_cran.Rd
@@ -7,7 +7,7 @@
 check_cran(pkgs, libpath = file.path(tempdir(), "R-lib"), srcpath = libpath,
   bioconductor = FALSE, type = getOption("pkgType"),
   threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"),
-  env_vars = NULL)
+  install_dir = tempfile("check_cran_install"), env_vars = NULL)
 }
 \arguments{
 \item{pkgs}{Vector of package names - note that unlike other \pkg{devtools}
@@ -29,7 +29,8 @@ to the same type as \code{\link{install.packages}()}.}
 \item{threads}{Number of concurrent threads to use for checking.
 It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
 
-\item{check_dir}{Directory to store results.}
+\item{check_dir, install_dir}{Directory to store check and installation
+results.}
 
 \item{env_vars}{Environment variables set during \code{R CMD check}}
 }

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -8,7 +8,8 @@ install(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   args = getOption("devtools.install.args"), quiet = FALSE,
   dependencies = NA, upgrade_dependencies = TRUE, build_vignettes = FALSE,
   keep_source = getOption("keep.source.pkgs"), threads = getOption("Ncpus",
-  1), force_deps = FALSE, metadata = remote_metadata(as.package(pkg)), ...)
+  1), force_deps = FALSE, metadata = remote_metadata(as.package(pkg)),
+  out_dir = NULL, skip_if_log_exists = FALSE, ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -57,6 +58,11 @@ SHA1 reference hasn't changed from the currently installed version.}
 
 \item{metadata}{Named list of metadata entries to be added to the
 \code{DESCRIPTION} after installation.}
+
+\item{out_dir}{Directory to store installation output in case of failure.}
+
+\item{skip_if_log_exists}{If the \code{out_dir} is defined and contains
+a file named \code{package.out}, no installation is attempted.}
 
 \item{...}{additional arguments passed to \code{\link{install.packages}}
 when installing dependencies. \code{pkg} is installed with

--- a/man/revdep_check.Rd
+++ b/man/revdep_check.Rd
@@ -16,7 +16,8 @@ revdep_check(pkg = ".", recursive = FALSE, ignore = NULL,
   dependencies = c("Depends", "Imports", "Suggests", "LinkingTo"),
   libpath = getOption("devtools.revdep.libpath"), srcpath = libpath,
   bioconductor = FALSE, type = getOption("pkgType"),
-  threads = getOption("Ncpus", 1), env_vars = NULL, check_dir = NULL)
+  threads = getOption("Ncpus", 1), env_vars = NULL, check_dir = NULL,
+  install_dir = NULL)
 
 revdep_check_resume(pkg = ".")
 
@@ -57,6 +58,9 @@ It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
 \item{check_dir}{A temporary directory to hold the results of the package
 checks. This should not exist as after the revdep checks complete
 successfully this directory is blown away.}
+
+\item{install_dir}{Directory to store check and installation
+results.}
 }
 \value{
 An invisible list of results. But you'll probably want to look


### PR DESCRIPTION
- revdep_check() and check_cran() gain "install_dir" argument
    - default value assumed in revdep_check()
- output for failed installations is collected there in <package-name>.out
  files
- presence of such a file omits attempts to download and install
     - via new "out_dir" and "skip_if_log_exists" arguments

Closes #1284 (=includes it).

NEWS entry:

```
* Installation failures are logged during revdep checking, by default in
  `revdep/install`. Once an installation has failed, it is not attempted
  a second time (#1300, @krlmlr).
```