### PR TITLE
Show timing information

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.12.0.9000
 
+* `revdep_check()` collects timing information in `timing.md` (#1319, @krlmlr).
+
 * Improve Git status checks used in `release()` (#1205, @krlmlr).
 
 * Various minor improvements around checking of reverse dependencies

--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -139,3 +139,7 @@ status_update <- function(i, n, start_time) {
 write_check_time <- function(i, pkgs, elapsed_time, path) {
   writeLines(sprintf("%d  %s  %.1f", i, pkgs, elapsed_time), path)
 }
+
+parse_check_time <- function(path) {
+  read.table(file = path, header = FALSE)[[3]]
+}

--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -97,11 +97,9 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
       message("Checked ", pkg_names[i], ": ", summarise_check_results(res, colour = TRUE))
       status_update(i, length(pkgs), check_start)
 
-      elapsed_time <- as.numeric(end_time - start_time, units = "secs")
-      writeLines(
-        sprintf("%d  %s  %.1f", i, pkgs[i], elapsed_time),
-        file.path(check_dir, paste0(pkgs[i], ".Rcheck"), "check-time.txt")
-      )
+      write_check_time(
+        i, pkgs[i], elapsed_time = as.numeric(end_time - start_time, units = "secs"),
+        file.path(check_dir, paste0(pkgs[i], ".Rcheck"), "check-time.txt"))
 
       NULL
     }
@@ -136,4 +134,8 @@ status_update <- function(i, n, start_time) {
     i, n, hm(elapsed), hm(estimated)
   )
   message(msg)
+}
+
+write_check_time <- function(i, pkgs, elapsed_time, path) {
+  writeLines(sprintf("%d  %s  %.1f", i, pkgs, elapsed_time), path)
 }

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -81,7 +81,7 @@ revdep_check_results_md <- function(results, has_problem) {
   summaries <- vapply(results, format, character(1))
 
   paste0(
-    "# Check results\n",
+    "# Check results\n\n",
     paste0(length(summaries), " ", msg, "\n\n"),
     summary_table,
     timing,

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -3,12 +3,18 @@
 revdep_check_save_summary <- function(pkg = ".") {
   pkg <- as.package(pkg)
 
+  revdep_check_save_readme(pkg)
+  revdep_check_save_problems(pkg)
+}
+
+revdep_check_save_readme <- function(pkg) {
   md_all <- revdep_check_summary_md(pkg)
   writeLines(md_all, file.path(pkg$path, "revdep", "README.md"))
+}
 
+revdep_check_save_problems <- function(pkg) {
   md_bad <- revdep_check_summary_md(pkg, has_problem = TRUE)
   writeLines(md_bad, file.path(pkg$path, "revdep", "problems.md"))
-
 }
 
 revdep_check_summary_md <- function(pkg, has_problem = FALSE) {

--- a/R/revdep-summarise.R
+++ b/R/revdep-summarise.R
@@ -64,13 +64,27 @@ revdep_check_results_md <- function(results, has_problem) {
     msg <- "packages"
   }
 
+  summary_table <- paste0(
+    paste0(revdep_check_results_kable(results), collapse = "\n"),
+    "\n\n")
+
+  if (has_problem) {
+    timing <- ""
+  } else {
+    timing <- paste0(
+      "Slowest checks\n\n",
+      paste0(revdep_check_timing_kable(results), collapse = "\n"),
+      "\n\n"
+    )
+  }
+
   summaries <- vapply(results, format, character(1))
 
   paste0(
     "# Check results\n",
     paste0(length(summaries), " ", msg, "\n\n"),
-    paste0(revdep_check_results_kable(results), collapse = "\n"),
-    "\n\n",
+    summary_table,
+    timing,
     paste0(summaries, collapse = "\n")
   )
 }
@@ -88,6 +102,20 @@ revdep_check_results_kable <- function(results) {
   rownames(summary_df) <- NULL
 
   knitr::kable(summary_df)
+}
+
+revdep_check_timing_kable <- function(results) {
+  if (length(results) == 0) return(character())
+
+  timing_df <- data.frame(
+    package = I(names(results)),
+    check_time = I(vapply(results, function(x) x$check_time, numeric(1)))
+  )
+  rownames(timing_df) <- NULL
+
+  timing_df <- utils::head(timing_df[order(-timing_df$check_time), ])
+
+  knitr::kable(timing_df)
 }
 
 #' @export

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -276,6 +276,7 @@ parse_package_check <- function(path) {
       bug_reports = desc$BugReports,
       package = desc$Package,
       version = desc$Version,
+      check_time = parse_check_time(file.path(path, "check-time.txt")),
       results = parse_check_results(file.path(path, "00check.log"))
     ),
     class = "revdep_check_result"


### PR DESCRIPTION
for the 6 slowest packages.

Example output ([source](https://github.com/rstats-db/RSQLite/blame/5776963f8bd74902c0ef7989cb709d120031d62e/revdep/README.md#L145-L154)):

Slowest checks

|   |package           | check_time|
|:--|:-----------------|----------:|
|3  |AnnotationHubData |     4837.7|
|4  |AnnotationHub     |     3921.7|
|36 |GenomicFeatures   |       3660|
|28 |ensembldb         |      733.3|
|62 |OrganismDbi       |      674.9|
|42 |lumi              |      484.5|

Motivation: A sudden change in timing may hint to a bug; ignore notoriously slow packages.