### PR TITLE
Ignore temporary revdep/.check.rds after use_revdep()

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -555,6 +555,7 @@ use_revdep <- function(pkg = ".") {
     data = list(name = pkg$package),
     pkg = pkg
   )
+  use_git_ignore(revdep_cache_path(""), pkg = pkg)
 }
 
 #' @rdname infrastructure

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -555,7 +555,7 @@ use_revdep <- function(pkg = ".") {
     data = list(name = pkg$package),
     pkg = pkg
   )
-  use_git_ignore(revdep_cache_path(""), pkg = pkg)
+  use_git_ignore(revdep_cache_path_raw(""), pkg = pkg)
 }
 
 #' @rdname infrastructure

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -287,7 +287,7 @@ revdep_check_path <- function(pkg) {
 }
 
 revdep_cache_path <- function(pkg) {
-  revdep_cache_path(pkg$path)
+  revdep_cache_path_raw(pkg$path)
 }
 
 revdep_cache_path_raw <- function(path) {

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -287,7 +287,11 @@ revdep_check_path <- function(pkg) {
 }
 
 revdep_cache_path <- function(pkg) {
-  file.path(pkg$path, "revdep", ".cache.rds")
+  if (!is.package(pkg))
+    path <- pkg
+  else
+    path <- pkg$path
+  file.path(path, "revdep", ".cache.rds")
 }
 
 check_dirs <- function(path) {

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -287,10 +287,10 @@ revdep_check_path <- function(pkg) {
 }
 
 revdep_cache_path <- function(pkg) {
-  if (!is.package(pkg))
-    path <- pkg
-  else
-    path <- pkg$path
+  revdep_cache_path(pkg$path)
+}
+
+revdep_cache_path_raw <- function(path) {
   file.path(path, "revdep", ".cache.rds")
 }
 


### PR DESCRIPTION
otherwire check summary won't show package SHA