### PR TITLE
Add dictionary argument to spell_check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ r:
  - release
  - devel
 
-addons:
-  apt:
-    packages:
-      - libhunspell-dev
-
 # We want to use devel devtools to load packages so we can catch package
 # installation issues sooner rather than later.
 r_github_packages:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     jsonlite,
     stats,
     git2r (>= 0.11.0),
+    hunspell (>= 2.0),
     withr
 Suggests:
     curl (>= 0.9),
@@ -36,7 +37,6 @@ Suggests:
     MASS,
     rmarkdown,
     knitr,
-    hunspell (>= 1.2),
     lintr (>= 0.2.1),
     bitops,
     roxygen2 (>= 5.0.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Imports:
     jsonlite,
     stats,
     git2r (>= 0.11.0),
-    hunspell (>= 2.0),
     withr
 Suggests:
     curl (>= 0.9),
@@ -37,6 +36,7 @@ Suggests:
     MASS,
     rmarkdown,
     knitr,
+    hunspell (>= 2.0),
     lintr (>= 0.2.1),
     bitops,
     roxygen2 (>= 5.0.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@
   (@ijlyttle, #1101)
   
 * `spell_check` gains a `dict` argument to set a custom language or dictionary
+
+* `release()` now checks documentation for spelling errors by default. 
   
 ## Bug fixes and minor improvements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
 * `use_github()` accepts a host argument, similar to `install_github()` 
   (@ijlyttle, #1101)
   
+* `spell_check` gains a `dict` argument to set a custom language or dictionary
+  
 ## Bug fixes and minor improvements
 
 * Update with Rtools-3.4 information, (@jimhester)

--- a/R/release.r
+++ b/R/release.r
@@ -39,8 +39,10 @@
 #'   release it.
 #' @param args An optional character vector of additional command
 #'   line arguments to be passed to \code{R CMD build}.
+#' @param spelling language or dictionary file to spell check documentation.
+#' See \code{\link{spell_check}}. Set to \code{NULL} to skip spell checking.
 #' @export
-release <- function(pkg = ".", check = TRUE, args = NULL) {
+release <- function(pkg = ".", check = TRUE, args = NULL, spelling = "en_US") {
   pkg <- as.package(pkg)
   # Figure out if this is a new package
   cran_version <- cran_pkg_version(pkg$package)
@@ -57,6 +59,14 @@ release <- function(pkg = ".", check = TRUE, args = NULL) {
   if (uses_git(pkg$path)) {
     git_checks(pkg)
     if (yesno("Were Git checks successful?"))
+      return(invisible())
+  }
+
+  if (length(spelling)) {
+    cat("Spell checking documentation...\n")
+    print(spell_check(pkg, dict = spelling))
+    cat("\n")
+    if (yesno("Is documentation free of spelling errors? (you can ignore false positives)"))
       return(invisible())
   }
 

--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -1,7 +1,10 @@
 #' Spell checking
 #'
 #' Runs a spell check on text fields in the package description file and
-#' manual pages.
+#' manual pages. Hunspell includes dictionaries for \code{en_US} and \code{en_GB}
+#' by default. Other languages require installation of a custom dictionary, see
+#' the \href{https://cran.r-project.org/web/packages/hunspell/vignettes/intro.html#system_dictionaries}{hunspell vignette}
+#' for details.
 #'
 #' @export
 #' @rdname spell_check
@@ -9,18 +12,20 @@
 #'   \code{\link{as.package}} for more information
 #' @param ignore character vector with words to ignore. See
 #'   \code{\link[hunspell:hunspell]{hunspell}} for more information
-spell_check <- function(pkg = ".", ignore = character()){
+#' @param dict a dictionary object or language string. See
+#'   \code{\link[hunspell:hunspell]{hunspell}} for more information
+spell_check <- function(pkg = ".", ignore = character(), dict = "en_US"){
   pkg <- as.package(pkg)
   ignore <- c(pkg$package, hunspell::en_stats, ignore)
 
   # Check Rd manual files
   rd_files <- list.files(file.path(pkg$path, "man"), "\\.Rd$", full.names = TRUE)
-  rd_lines <- lapply(sort(rd_files), spell_check_rd, ignore = ignore)
+  rd_lines <- lapply(sort(rd_files), spell_check_rd, ignore = ignore, dict = dict)
 
   # Check 'DESCRIPTION' fields
   pkg_fields <- c("title", "description")
   pkg_lines <- lapply(pkg_fields, function(x){
-    spell_check_file(textConnection(pkg[[x]]), ignore = ignore)
+    spell_check_file(textConnection(pkg[[x]]), ignore = ignore, dict = dict)
   })
 
   # Combine
@@ -52,19 +57,19 @@ print.spellcheck <- function(x, ...){
   }
 }
 
-spell_check_text <- function(text, ignore){
-  bad_words <- hunspell::hunspell(text, ignore = ignore)
+spell_check_text <- function(text, ignore, dict){
+  bad_words <- hunspell::hunspell(text, ignore = ignore, dict = dict)
   vapply(sort(unique(unlist(bad_words))), function(word) {
     line_numbers <- which(vapply(bad_words, `%in%`, x = word, logical(1)))
     paste(line_numbers, collapse = ",")
   }, character(1))
 }
 
-spell_check_file <- function(file, ignore){
-  spell_check_text(readLines(file), ignore = ignore)
+spell_check_file <- function(file, ignore, dict){
+  spell_check_text(readLines(file), ignore = ignore, dict = dict)
 }
 
-spell_check_rd <- function(rdfile, ignore){
+spell_check_rd <- function(rdfile, ignore, dict){
   text <- tools::RdTextFilter(rdfile)
-  spell_check_text(text, ignore = ignore)
+  spell_check_text(text, ignore = ignore, dict = dict)
 }

--- a/man/release.Rd
+++ b/man/release.Rd
@@ -4,7 +4,7 @@
 \alias{release}
 \title{Release package to CRAN.}
 \usage{
-release(pkg = ".", check = TRUE, args = NULL)
+release(pkg = ".", check = TRUE, args = NULL, spelling = "en_US")
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -16,6 +16,9 @@ release it.}
 
 \item{args}{An optional character vector of additional command
 line arguments to be passed to \code{R CMD build}.}
+
+\item{spelling}{language or dictionary file to spell check documentation.
+See \code{\link{spell_check}}. Set to \code{NULL} to skip spell checking.}
 }
 \description{
 Run automated and manual tests, then ftp to CRAN.

--- a/man/spell_check.Rd
+++ b/man/spell_check.Rd
@@ -4,7 +4,7 @@
 \alias{spell_check}
 \title{Spell checking}
 \usage{
-spell_check(pkg = ".", ignore = character())
+spell_check(pkg = ".", ignore = character(), dict = "en_US")
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -12,9 +12,15 @@ spell_check(pkg = ".", ignore = character())
 
 \item{ignore}{character vector with words to ignore. See
 \code{\link[hunspell:hunspell]{hunspell}} for more information}
+
+\item{dict}{a dictionary object or language string. See
+\code{\link[hunspell:hunspell]{hunspell}} for more information}
 }
 \description{
 Runs a spell check on text fields in the package description file and
-manual pages.
+manual pages. Hunspell includes dictionaries for \code{en_US} and \code{en_GB}
+by default. Other languages require installation of a custom dictionary, see
+the \href{https://cran.r-project.org/web/packages/hunspell/vignettes/intro.html#system_dictionaries}{hunspell vignette}
+for details.
 }
 


### PR DESCRIPTION
You can now use a custom language in `spell_check` for example:

``` r
spell_check(dict = "en_GB")
```

Also `hunspell` is now entirely self-contained (it has zero system dependencies) so I think we can just import it. Also added a feature that will automatically check documentation on release (as [suggested](https://github.com/hadley/devtools/pull/1119#issuecomment-200390768) by @hadley ).

Hopefully this will encourage users to eliminate typo's from documentation :) 
