### PR TITLE
These changes address uses non-standard CRAN like repositories e.g. (drat)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # devtools 1.12.0.9000
+* Bugfix for installation of dependencies in CRAN-like repositories such as
+  those created by drat (@jimhester, #1243, #1339).
 
 * Improve Git status checks used in `release()` (#1205, @krlmlr).
 

--- a/R/cran.r
+++ b/R/cran.r
@@ -1,5 +1,5 @@
 available_packages <- memoise::memoise(function(repos, type) {
-  suppressWarnings(available.packages(contrib.url(repos, type), type = type))
+  available.packages(contrib.url(repos, type), type = type)
 })
 
 package_url <- function(package, repos,

--- a/R/deps.R
+++ b/R/deps.R
@@ -18,10 +18,7 @@
 #' @param quiet If \code{TRUE}, suppress output.
 #' @param upgrade If \code{TRUE}, also upgrade any of out date dependencies.
 #' @param repos A character vector giving repositories to use.
-#' @param type Type of package to \code{update}.  If "both", will switch
-#'   automatically to "binary" to avoid interactive prompts during package
-#'   installation.
-#'
+#' @param type Type of package to \code{update}.
 #' @param object A \code{package_deps} object.
 #' @param ... Additional arguments passed to \code{install_packages}.
 #'
@@ -47,9 +44,6 @@
 #' }
 package_deps <- function(pkg, dependencies = NA, repos = getOption("repos"),
                          type = getOption("pkgType")) {
-  if (identical(type, "both")) {
-    type <- "binary"
-  }
 
   if (length(repos) == 0)
     repos <- character()
@@ -311,8 +305,6 @@ update.package_deps <- function(object, ..., quiet = FALSE, upgrade = TRUE) {
 install_packages <- function(pkgs, repos = getOption("repos"),
                              type = getOption("pkgType"), ...,
                              dependencies = FALSE, quiet = NULL) {
-  if (identical(type, "both"))
-    type <- "binary"
   if (is.null(quiet))
     quiet <- !identical(type, "source")
 
@@ -327,8 +319,9 @@ install_packages <- function(pkgs, repos = getOption("repos"),
     old <- add_path(get_rtools_path(), 0)
     on.exit(set_path(old))
   }
-  utils::install.packages(pkgs, repos = repos, type = type,
-    dependencies = dependencies, quiet = quiet)
+  withr::with_options("install.packages.compile.from.source" = "never",
+    utils::install.packages(pkgs, repos = repos, type = type,
+      dependencies = dependencies, quiet = quiet))
 }
 
 find_deps <- function(pkgs, available = available.packages(), top_dep = TRUE,

--- a/R/install.r
+++ b/R/install.r
@@ -177,7 +177,7 @@ install_deps <- function(pkg = ".", dependencies = NA,
 
   pkg <- dev_package_deps(pkg, repos = repos, dependencies = dependencies,
     type = type)
-  update(pkg, ..., Ncpus = threads, quiet = quiet, upgrade = upgrade)
+  update(pkg, ..., repos = repos, Ncpus = threads, quiet = quiet, upgrade = upgrade)
   invisible()
 }
 

--- a/man/install_cran.Rd
+++ b/man/install_cran.Rd
@@ -12,9 +12,7 @@ install_cran(pkgs, repos = getOption("repos"), type = getOption("pkgType"),
 
 \item{repos}{A character vector giving repositories to use.}
 
-\item{type}{Type of package to \code{update}.  If "both", will switch
-automatically to "binary" to avoid interactive prompts during package
-installation.}
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{Additional arguments passed to \code{install_packages}.}
 

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -25,9 +25,7 @@ It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
 
 \item{repos}{A character vector giving repositories to use.}
 
-\item{type}{Type of package to \code{update}.  If "both", will switch
-automatically to "binary" to avoid interactive prompts during package
-installation.}
+\item{type}{Type of package to \code{update}.}
 
 \item{...}{additional arguments passed to \code{\link{install.packages}}.}
 

--- a/man/package_deps.Rd
+++ b/man/package_deps.Rd
@@ -29,9 +29,7 @@ the name of the package in the current directory.}
 
 \item{repos}{A character vector giving repositories to use.}
 
-\item{type}{Type of package to \code{update}.  If "both", will switch
-automatically to "binary" to avoid interactive prompts during package
-installation.}
+\item{type}{Type of package to \code{update}.}
 
 \item{object}{A \code{package_deps} object.}
 

--- a/man/update_packages.Rd
+++ b/man/update_packages.Rd
@@ -22,9 +22,7 @@ installed packages are updated.}
 
 \item{repos}{A character vector giving repositories to use.}
 
-\item{type}{Type of package to \code{update}.  If "both", will switch
-automatically to "binary" to avoid interactive prompts during package
-installation.}
+\item{type}{Type of package to \code{update}.}
 }
 \description{
 Works similarly to \code{install.packages()} but doesn't install packages


### PR DESCRIPTION
This PR addresses https://github.com/hadley/devtools/issues/1243.

There were two issues, first the prior behavior of forcing `type = binary` was causing drat repositories without binary packages to fail, second the `repos` argument was not being passed onto `update()`.

With these changes the following correctly installs `rrdf` and `rrdflibs` as expected by @cboettig.

``` r
devtools::install_github("ropensci/RNeXML", dep=TRUE, repos = c("https://cran.rstudio.com", "http://packages.ropensci.org"))
```
