### PR TITLE
Small markdown formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ You can track (and contribute to) the development of `devtools` at https://githu
 
 3. Install the development version of devtools.
 
-        ```R
-        devtools::install_github("hadley/devtools")
-        ```
+   ```R
+   devtools::install_github("hadley/devtools")
+   ```
 
 ## Package development tools
 


### PR DESCRIPTION
Avoid rendering backtick literals by preserving list indentation

**before**
<img width="397" alt="screen shot 2016-09-12 at 9 10 07 pm" src="https://cloud.githubusercontent.com/assets/8942/18461326/598c1f3a-792d-11e6-8002-35366c8e4c3b.png">

**after**
<img width="404" alt="screen shot 2016-09-12 at 9 10 14 pm" src="https://cloud.githubusercontent.com/assets/8942/18461324/5506133a-792d-11e6-900f-6623eb7e7da6.png">
