### PR TITLE
Add release check for junk files in inst/doc/  (fix #1361)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # devtools 1.12.0.9000
+* Added release_check for files in inst/doc/ that could prevent 
+vignettes from building. (@wmurphyrd, #1361)
+
 * Bugfix for installation of dependencies in CRAN-like repositories such as
   those created by drat (@jimhester, #1243, #1339).
 

--- a/R/check-devtools.r
+++ b/R/check-devtools.r
@@ -16,6 +16,7 @@ release_checks <- function(pkg = ".", built_path = NULL) {
   check_vignette_titles(pkg)
   check_news_md(pkg)
   check_remotes(pkg)
+  check_doc_files(pkg)
 }
 
 check_dev_versions <- function(pkg = ".") {
@@ -132,4 +133,14 @@ check_status <- function(status, name, warning) {
   )
 
   invisible(status)
+}
+
+check_doc_files <- function(pkg) {
+  pkg <- as.package(pkg)
+  doc_path <- file.path(pkg$path, "inst", "doc")
+
+  check_status(length(dir(doc_path)) == 0,
+               "/inst/doc does not contain errant files",
+               "Vignette testing files should be removed with clean_vignettes"
+  )
 }

--- a/tests/testthat/test-release.r
+++ b/tests/testthat/test-release.r
@@ -1,0 +1,13 @@
+context("Release checks")
+
+test_that("check_doc_files", {
+  path <- file.path(tempdir(), "testpkg1")
+  if (length(dir(path))) unlink(path, recursive = TRUE)
+  capture.output(create(path))
+  use_vignette("example", path)
+
+  expect_message(capture.output(check_doc_files(path)), NA)
+
+  build_vignettes(path)
+  expect_message(capture.output(check_doc_files(path)))
+})


### PR DESCRIPTION
- New function `doc_files()` returns `TRUE` if files exist in inst/doc/
- Added to `release()` workflow with explanation that files may prevent vignettes from building
- Added tests/testthat/test-release.r with tests for `doc_files()`
