### PR TITLE
Don't pass skip to check_cran()

### DIFF
--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -43,6 +43,9 @@ check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
   stopifnot(is.character(pkgs))
   if (length(pkgs) == 0) return()
 
+  # For installing from GitHub, if git2r is not installed in the check_libpath
+  requireNamespace("git2r", quietly = TRUE)
+
   rule("Checking ", length(pkgs), " CRAN packages", pad = "=")
   if (!file.exists(check_dir)) dir.create(check_dir)
   message("Results saved in ", check_dir)

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -267,6 +267,7 @@ revdep_check_from_cache <- function(pkg, cache) {
     message("Skipping: ", comma(cache$skip))
     cache$pkgs <- setdiff(cache$pkgs, cache$skip)
   }
+  cache$skip <- NULL
 
   do.call(check_cran, cache)
 

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -230,6 +230,9 @@ revdep_check_from_cache <- function(pkg, cache) {
     "Installing dependencies for ", pkg$package, " to ", cache$libpath
   )
 
+  # For installing from GitHub, if git2r is not installed in the cache$libpath
+  requireNamespace("git2r", quietly = TRUE)
+
   withr::with_libpaths(cache$libpath, {
     install_deps(pkg, reload = FALSE, quiet = TRUE, dependencies = TRUE)
   })


### PR DESCRIPTION
Follow-up to #1366.

@jcheng5: Can you please try:

```r
devtools::install_github("hadley/devtools#1368")
```

@hadley: I broke revdep check, this PR fixes it.