### PR TITLE
Remove deprecated `args` argument from `install_git()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,8 @@
 * fix auto download method selection for `install_github()` on R 3.1 which
   lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)
 
+* Remove deprecated `args` argument from `install_git()` to allow passthrough to `install` (#1373, @ReportMort).
+
 # devtools 1.12.0
 
 ## New features

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -10,8 +10,6 @@
 #' @param branch Name of branch or tag to use, if not master.
 #' @param credentials A git2r credentials object passed through
 #'   to \code{\link[git2r]{clone}}.
-#' @param args DEPRECATED. A character vector providing extra arguments to
-#'   pass on to git.
 #' @param ... passed on to \code{\link{install}}
 #' @export
 #' @family package installation
@@ -20,10 +18,7 @@
 #' install_git("git://github.com/hadley/stringr.git")
 #' install_git("git://github.com/hadley/stringr.git", branch = "stringr-0.2")
 #'}
-install_git <- function(url, subdir = NULL, branch = NULL, credentials = NULL,
-  args = character(0), ...) {
-  if (!missing(args))
-    warning("`args` is deprecated", call. = FALSE)
+install_git <- function(url, subdir = NULL, branch = NULL, credentials = NULL, ...) {
 
   remotes <- lapply(url, git_remote, subdir = subdir,
                     branch = branch, credentials=credentials)

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -10,6 +10,7 @@
 #' @param branch Name of branch or tag to use, if not master.
 #' @param credentials A git2r credentials object passed through
 #'   to \code{\link[git2r]{clone}}.
+#' @param quiet if \code{TRUE} suppresses output from this function.
 #' @param ... passed on to \code{\link{install}}
 #' @export
 #' @family package installation
@@ -18,12 +19,12 @@
 #' install_git("git://github.com/hadley/stringr.git")
 #' install_git("git://github.com/hadley/stringr.git", branch = "stringr-0.2")
 #'}
-install_git <- function(url, subdir = NULL, branch = NULL, credentials = NULL, ...) {
+install_git <- function(url, subdir = NULL, branch = NULL, credentials = NULL, quiet=FALSE, ...) {
 
   remotes <- lapply(url, git_remote, subdir = subdir,
                     branch = branch, credentials=credentials)
 
-  install_remotes(remotes, ...)
+  install_remotes(remotes, quiet = quiet, ...)
 }
 
 git_remote <- function(url, subdir = NULL, branch = NULL, credentials=NULL) {

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -4,7 +4,8 @@
 \alias{install_git}
 \title{Install a package from a git repository}
 \usage{
-install_git(url, subdir = NULL, branch = NULL, credentials = NULL, ...)
+install_git(url, subdir = NULL, branch = NULL, credentials = NULL,
+  quiet = FALSE, ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -17,6 +18,8 @@ contain the package we are interested in installing.}
 
 \item{credentials}{A git2r credentials object passed through
 to \code{\link[git2r]{clone}}.}
+
+\item{quiet}{if \code{TRUE} suppresses output from this function.}
 
 \item{...}{passed on to \code{\link{install}}}
 }

--- a/man/install_git.Rd
+++ b/man/install_git.Rd
@@ -4,8 +4,7 @@
 \alias{install_git}
 \title{Install a package from a git repository}
 \usage{
-install_git(url, subdir = NULL, branch = NULL, credentials = NULL,
-  args = character(0), ...)
+install_git(url, subdir = NULL, branch = NULL, credentials = NULL, ...)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
@@ -18,9 +17,6 @@ contain the package we are interested in installing.}
 
 \item{credentials}{A git2r credentials object passed through
 to \code{\link[git2r]{clone}}.}
-
-\item{args}{DEPRECATED. A character vector providing extra arguments to
-pass on to git.}
 
 \item{...}{passed on to \code{\link{install}}}
 }


### PR DESCRIPTION
resolves #1373 and also fixes an issue where the `quiet` argument was explicitly stated in `try_install_remote()` and throwing error if not explicitly provided upstream.
