### PR TITLE
fix load_all in windows with UTF8 codes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@
 
 * fix auto download method selection for `install_github()` on R 3.1 which
   lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)
+  
+* fix `load_all()` for UTF-8 scripts under windows. (@shrektan, #1378)
 
 # devtools 1.12.0
 

--- a/R/load-code.r
+++ b/R/load-code.r
@@ -23,7 +23,8 @@ load_code <- function(pkg = ".") {
   }
   on.exit(cleanup())
 
-  withr_with_dir(file.path(pkg$path), source_many(paths, env))
+  withr_with_dir(file.path(pkg$path),
+                 source_many(paths, env, fileEncoding = pkg$encoding %||% "UTF-8"))
   success <- TRUE
 
   invisible(r_files)

--- a/R/source.r
+++ b/R/source.r
@@ -1,4 +1,4 @@
-source_many <- function(files, envir = parent.frame()) {
+source_many <- function(files, envir = parent.frame(), fileEncoding = "UTF-8") {
   stopifnot(is.character(files))
   stopifnot(is.environment(envir))
 
@@ -9,16 +9,18 @@ source_many <- function(files, envir = parent.frame()) {
   on.exit(options(oop))
 
   for (file in files) {
-    source_one(file, envir = envir)
+    source_one(file, envir = envir, fileEncoding = fileEncoding)
   }
   invisible()
 }
 
-source_one <- function(file, envir = parent.frame()) {
+source_one <- function(file, envir = parent.frame(), fileEncoding = "UTF-8") {
   stopifnot(file.exists(file))
   stopifnot(is.environment(envir))
 
-  lines <- readLines(file, warn = FALSE, encoding = "UTF-8")
+  con <- file(file, encoding = fileEncoding)
+  on.exit(close(con), add = TRUE)
+  lines <- readLines(con, warn = FALSE, encoding = fileEncoding)
   lines <- enc2native(lines)
   srcfile <- srcfilecopy(file, lines, file.info(file)[1, "mtime"],
     isFile = TRUE)

--- a/R/source.r
+++ b/R/source.r
@@ -18,7 +18,8 @@ source_one <- function(file, envir = parent.frame()) {
   stopifnot(file.exists(file))
   stopifnot(is.environment(envir))
 
-  lines <- readLines(file, warn = FALSE)
+  lines <- readLines(file, warn = FALSE, encoding = "UTF-8")
+  lines <- enc2native(lines)
   srcfile <- srcfilecopy(file, lines, file.info(file)[1, "mtime"],
     isFile = TRUE)
   exprs <- parse(text = lines, n = -1, srcfile = srcfile)

--- a/tests/testthat/test-load-nonASCII.R
+++ b/tests/testthat/test-load-nonASCII.R
@@ -1,0 +1,7 @@
+context("Load: Non-ASCII Encoding")
+
+test_that("Load nonASCII encoded files correctly", {
+  load_all("testNonASCII")
+  expect_message(printChineseMsg(), "我是GB2312的中文字符。")
+  expect_output(print(printChineseMsg), "我是GB2312的中文字符。")
+})

--- a/tests/testthat/testNonASCII/DESCRIPTION
+++ b/tests/testthat/testNonASCII/DESCRIPTION
@@ -1,0 +1,8 @@
+Package: testNonASCII
+Title: Test no change to Collate when there are no @includes
+License: GPL-2
+Description:
+Author: Shrektan <shrektan@126.com>
+Maintainer: Shrektan <shrektan@126.com>
+Encoding: GB2312
+Version: 0.1

--- a/tests/testthat/testNonASCII/R/a.r
+++ b/tests/testthat/testNonASCII/R/a.r
@@ -1,0 +1,9 @@
+# This script is intended to be saved in GB2312 to test if non UTF-8 encoding is
+# supported.
+
+#' 中文注释
+#'
+#' @note 我爱中文。
+printChineseMsg <- function() {
+  message("我是GB2312的中文字符。")
+}


### PR DESCRIPTION
If the source file contains nonASCII chars, like Chinese Chars, `devtools::load_all()` would fail with error as below, but `Build & Reload` the package works fine.

I think it's due to not explicitly setting the `encoding` param in `readLines` of `source_one`, see https://github.com/hadley/devtools/blob/master/R/source.r#L21
### The error message sample

```
Loading package_abc
Error in parse(text = lines, n = -1, srcfile = srcfile) :
  invalid multibyte character in parser at line 12
In addition: Warning messages:
1: In grepl("\n", lines, fixed = TRUE) :
  input string 12 is invalid in this locale
2: In grepl("\n", lines, fixed = TRUE) :
  input string 14 is invalid in this locale
3: In grepl("\n", lines, fixed = TRUE) :
  input string 15 is invalid in this locale
```
### Notes
1. add `encoding = "UTF-8"` in `readLines()` to fix the reading from the file
2. convert the lines to `native` encoding, so the printing of the function displays correctly
