### PR TITLE
Debug on 'install-github.r' code

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -127,8 +127,6 @@ github_contents <- function(remote, content_path, path_to_save) {
   utils::download.file(
     url = response$download_url,
     destfile = path_to_save,
-    cacheOK = TRUE,
-    quiet = TRUE,
-    extra = "--continue"
+    quiet = TRUE
   )
 }

--- a/R/github.R
+++ b/R/github.R
@@ -124,6 +124,11 @@ github_contents <- function(remote, content_path, path_to_save) {
     file.path("repos", owner, repo, "contents", parameters)
   response <- github_GET(path = target_path)
 
-  download_file_using_wget(url = response$download_url,
-                           destfile = path_to_save)
+  utils::download.file(
+    url = response$download_url,
+    destfile = path_to_save,
+    cacheOK = TRUE,
+    quiet = TRUE,
+    extra = "--continue"
+  )
 }

--- a/R/github.R
+++ b/R/github.R
@@ -8,7 +8,12 @@ github_auth <- function(token) {
 
 github_response <- function(req) {
   text <- httr::content(req, as = "text")
-  parsed <- jsonlite::fromJSON(text, simplifyVector = FALSE)
+  if (jsonlite::validate(text)) {
+    parsed <- jsonlite::fromJSON(text, simplifyVector = FALSE)
+  } else {
+    # Allow non-JSON, plan text content (ex. SHA-1)
+    parsed <- text
+  }
 
   if (httr::status_code(req) >= 400) {
     stop(github_error(req))

--- a/R/github.R
+++ b/R/github.R
@@ -108,3 +108,17 @@ github_pat <- function(quiet = FALSE) {
 in_ci <- function() {
   nzchar(Sys.getenv("CI"))
 }
+
+#' @references https://developer.github.com/v3/repos/contents/#get-contents
+github_contents <- function(remote, content_path, path_to_save) {
+  owner <- remote$username
+  repo <- remote$repo
+  parameters <- paste0(content_path, "?ref=", remote$ref)
+
+  target_path <-
+    file.path("repos", owner, repo, "contents", parameters)
+  response <- github_GET(path = target_path)
+
+  download_file_using_wget(url = response$download_url,
+                           destfile = path_to_save)
+}

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -77,7 +77,6 @@ remote_metadata.git_remote <- function(x, bundle = NULL, source = NULL) {
 
 #' @export
 remote_package_name.git_remote <- function(remote, ...) {
-
   tmp <- tempfile()
   on.exit(unlink(tmp))
   description_path <- paste0(collapse = "/", c(remote$subdir, "DESCRIPTION"))

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -253,17 +253,6 @@ remote_package_name.github_remote <- function(remote, ...) {
   read_dcf(tmp)$Package
 }
 
-download_file_using_wget <- function(url, destfile) {
-  utils::download.file(
-    url = url,
-    destfile = destfile,
-    cacheOK = TRUE,
-    method = "wget",
-    quiet = TRUE,
-    extra = "--continue"
-  )
-}
-
 #' @export
 #' @references https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference
 remote_sha.github_remote <- function(remote, ...) {

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -243,48 +243,67 @@ parse_git_repo <- function(path) {
 }
 
 #' @export
-remote_package_name.github_remote <- function(remote, url = "https://github.com", ...) {
-
+remote_package_name.github_remote <- function(remote, ...) {
   tmp <- tempfile()
-  path <- paste(c(
-      remote$username,
-      remote$repo,
-      "raw",
-      remote$ref,
-      remote$subdir,
-      "DESCRIPTION"), collapse = "/")
-
-  req <- httr::GET(url, path = path, httr::write_disk(path = tmp))
-
-  if (httr::status_code(req) >= 400) {
-    return(NA_character_)
-  }
+  on.exit(unlink(tmp))
+  get_contents_using_github_api(remote,
+                                content_path = "DESCRIPTION",
+                                path_to_save = tmp)
 
   read_dcf(tmp)$Package
 }
 
+#' @references https://developer.github.com/v3/repos/contents/#get-contents
+get_contents_using_github_api <-
+  function(remote, content_path, path_to_save) {
+    owner <- remote$username
+    repo <- remote$repo
+    target_path <-
+      file.path("repos", owner, repo, "contents", content_path)
+    response <- github_GET(path = target_path)
+
+    download_file_using_wget(url = response$download_url,
+                             destfile = path_to_save)
+  }
+
+download_file_using_wget <- function(url, destfile) {
+  utils::download.file(
+    url = url,
+    destfile = destfile,
+    cacheOK = TRUE,
+    method = "wget",
+    quiet = TRUE,
+    extra = "--continue"
+  )
+}
+
 #' @export
-remote_sha.github_remote <- function(remote, url = "https://github.com", ...) {
-  # If the remote ref is the same as the sha it is a pinned commit so just
-  # return that.
-  if (!is.null(remote$ref) && !is.null(remote$sha) &&
-    grepl(paste0("^", remote$ref), remote$sha)) {
+#' @references https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference
+remote_sha.github_remote <- function(remote, ...) {
+  if (has_sha.github_remote(remote)) {
     return(remote$sha)
   }
 
-  tryCatch({
-    res <- git2r::remote_ls(
-      paste0(url, "/", remote$username, "/", remote$repo, ".git"),
-      ...)
+  owner <- remote$username
+  repo <- remote$repo
+  ref <- remote$ref
+  target_path <- file.path("repos", owner, repo, "commits", ref)
 
-    found <- grep(pattern = paste0("/", remote$ref), x = names(res))
-
-    if (length(found) == 0) {
+  tryCatch(
+    expr = {
+      response <- github_GET(path = target_path)
+      return(response$sha)
+    },
+    error = function(e) {
       return(NA_character_)
     }
+  )
+}
 
-    unname(res[found[1]])
-  }, error = function(e) NA_character_)
+has_sha.github_remote <- function(remote) {
+  return(!is.null(remote$ref) &&
+           !is.null(remote$sha) &&
+           grepl(paste0("^", remote$ref), remote$sha))
 }
 
 #' @export

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -278,8 +278,10 @@ remote_sha.github_remote <- function(remote, ...) {
 
   tryCatch(
     expr = {
-      response <- github_GET(path = target_path)
-      return(response$sha)
+      remote_sha <-
+        github_GET(path = target_path,
+                   httr::add_headers(Accept = "application/vnd.github.VERSION.sha"))
+      return(remote_sha)
     },
     error = function(e) {
       return(NA_character_)

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -246,25 +246,12 @@ parse_git_repo <- function(path) {
 remote_package_name.github_remote <- function(remote, ...) {
   tmp <- tempfile()
   on.exit(unlink(tmp))
-  get_contents_using_github_api(remote,
-                                content_path = "DESCRIPTION",
-                                path_to_save = tmp)
+  github_contents(remote,
+                  content_path = "DESCRIPTION",
+                  path_to_save = tmp)
 
   read_dcf(tmp)$Package
 }
-
-#' @references https://developer.github.com/v3/repos/contents/#get-contents
-get_contents_using_github_api <-
-  function(remote, content_path, path_to_save) {
-    owner <- remote$username
-    repo <- remote$repo
-    target_path <-
-      file.path("repos", owner, repo, "contents", content_path)
-    response <- github_GET(path = target_path)
-
-    download_file_using_wget(url = response$download_url,
-                             destfile = path_to_save)
-  }
 
 download_file_using_wget <- function(url, destfile) {
   utils::download.file(


### PR DESCRIPTION
#### Fix #1381
## 
### The philosophy on this update
- Use `github_GET` rather than `httr::GET` directly when accessing `GitHub API`
  - `github_GET` is well abstracted
    - It aptly handle authentication and decode the response of `GitHub API`
  - Otherwise, using `httr::GET` directly can not systematically prevent omitting authentication
    - Present `remote_package_name.github_remote` show the exact problem mentioned above
    - hadley/devtools#1263 fix this with `if (!is.null(remote$auth_token)) { ... }`, but it still uses `httr::GET` directly
- Refer an official `GitHub API` documentation
  - For example, `remote_package_name.github_remote` includes the process of downloading a raw content from `GitHub`
    - `GitHub` provides [`get-contents API`](https://developer.github.com/v3/repos/contents/#get-contents) and this API can meet the case
    - So let's try to make use of this reliable tool rather than a custom approach
- Make the modified codes more readable, especially in the perspective of,
  - "Making functions smaller. "
  - "Don't mix different levels of abstractions. "
### Changes

(What has actually changed in the code)
- `R/install-git.r`
  - Modified: `remote_package_name.github_remote()`
    - Abstract the codes for downloading a `DESCRIPTION` file from `GitHub` as a new function `github_contents` ~~`get_contents_using_github_api`~~
      - In this design, we can reuse `get_contents_using_github_api` to get any contents in given `remote` object (not only just `DESCRIPTION`)
    - Remove argument `url` (It becomes dispensable so deprecated)
  - Added: `github_contents()` ~~`get_contents_using_github_api()`~~
    - Directly wraps [`'Get contents' GitHub API`](https://developer.github.com/v3/repos/contents/#get-contents)
      - This API returns the download URL of a content (in `download_url` field)
    - To download a raw content it uses a new function `download_file_using_wget`
  - ~~Added: `download_file_using_wget`~~
    - ~~Wrapper of `utils::download.file` with proper and useful options~~
    - ~~When a download fails, simply run the same code again, then it will continue not start from the beginning~~
      - ~~The `extra = "--continue"` option for `utils::download.file()` makes this possible~~
  - Modified: `remote_sha.github_remote`
    - `remote_sha.github_remote` is not working when `remote` is a private
      - It seems that `git2r::remote_ls` is not working for private `GitHub` repositories
      - This issue cause unnecessary re-installation for the already instead private R packages
    - Directly wraps [`'Get the SHA-1 of a commit reference' GitHub API`](https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference)
      - Access to this API using `github_GET`
      - Previous if-clause in line 270 ~ 271 has been abstracted to `has_sha.github_remote()`
