### PR TITLE
Set envvars when sourcing testthat helpers during load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,10 @@
 * fix auto download method selection for `install_github()` on R 3.1 which
   lacks "libcurl" in `capabilities()`. (@kiwiroy, #1244)
 
+* `load_all()` now sets the `NOT_CRAN` environment variable when it
+  sources testthat helpers. It also sets `DEVTOOLS_LOAD` to "true" so
+  that you can check whether they are run during package loading.
+
 # devtools 1.12.0
 
 ## New features

--- a/R/load.r
+++ b/R/load.r
@@ -20,8 +20,10 @@
 #'   \item Runs \code{.onAttach()}, \code{.onLoad()} and \code{.onUnload()}
 #'     functions at the correct times.
 #'
-#'   \item If you use \pkg{testthat}, will load all test helpers so you
-#'     can access them interactively.
+#'   \item If you use \pkg{testthat}, will load all test helpers so
+#'     you can access them interactively. Devtools sets the
+#'     \code{DEVTOOLS_LOAD} environment variable to \code{"true"} to
+#'     let you check whether the helpers are run during package loading.
 #'
 #' }
 #'
@@ -186,7 +188,9 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 
   # Source test helpers into package environment
   if (uses_testthat(pkg)) {
-    testthat::source_test_helpers(find_test_dir(pkg$path), env = pkg_env(pkg))
+    withr::with_envvar(c(NOT_CRAN = "true", DEVTOOLS_LOAD = "true"),
+      testthat::source_test_helpers(find_test_dir(pkg$path), env = pkg_env(pkg))
+    )
   }
 
 

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -53,8 +53,10 @@ Currently \code{load_all}:
 \item Runs \code{.onAttach()}, \code{.onLoad()} and \code{.onUnload()}
     functions at the correct times.
 
-\item If you use \pkg{testthat}, will load all test helpers so you
-    can access them interactively.
+\item If you use \pkg{testthat}, will load all test helpers so
+    you can access them interactively. Devtools sets the
+    \code{DEVTOOLS_LOAD} environment variable to \code{"true"} to
+    let you check whether the helpers are run during package loading.
 
 }
 }


### PR DESCRIPTION
This sets `NOT_CRAN` when running testthat helpers as part of `load_all()`.

Also this sets `DEVTOOLS_LOAD` to make it possible to branch out code on loading (useful if a helper takes a long time to run for instance).