### PR TITLE
Fully install the package before revdep checking

### DIFF
--- a/R/revdep.R
+++ b/R/revdep.R
@@ -247,7 +247,8 @@ revdep_check_from_cache <- function(pkg, cache) {
     "Installing ", pkg$package, " ", pkg$version, " to ", temp_libpath
   )
   withr::with_libpaths(c(temp_libpath, cache$libpath), {
-    install(pkg, reload = FALSE, quiet = TRUE, dependencies = FALSE)
+    install(pkg, reload = FALSE, quiet = TRUE, dependencies = FALSE,
+            build_vignettes = TRUE)
   })
 
   cache$env_vars <- c(


### PR DESCRIPTION
During revdep checking, I found some packages actually had tests that depended on `system.file('docs', package)`. If the package is not fully installed, these tests will fail.