### PR TITLE
Replace httr download with download.file

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -154,10 +154,11 @@ first_upper <- function(x) {
 }
 
 download <- function(path, url, ...) {
-  request <- httr::GET(url, ...)
-  httr::stop_for_status(request)
-  writeBin(httr::content(request, "raw"), path)
-  path
+  if (utils::download.file(url, path, mode = "wb") == 0) {
+    path
+  } else {
+    error()
+  }
 }
 
 download_text <- function(url, ...) {

--- a/R/utils.r
+++ b/R/utils.r
@@ -157,7 +157,7 @@ download <- function(path, url, ...) {
   if (utils::download.file(url, path, mode = "wb") == 0) {
     path
   } else {
-    error()
+    stop()
   }
 }
 


### PR DESCRIPTION
httr on Windows does not inherit 'internal' proxy authentication nor initializes wininet.dll authentication dialog. This change should sharply rise corporate windows user :::download() success rates.