### PR TITLE
Add ... to spell_check

### DIFF
--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -9,18 +9,19 @@
 #'   \code{\link{as.package}} for more information
 #' @param ignore character vector with words to ignore. See
 #'   \code{\link[hunspell:hunspell]{hunspell}} for more information
-spell_check <- function(pkg = ".", ignore = character()){
+#' @param ... additional arguments passed to \code{\link[hunspell:hunspell]{hunspell}}
+spell_check <- function(pkg = ".", ignore = character(), ...){
   pkg <- as.package(pkg)
   ignore <- c(pkg$package, hunspell::en_stats, ignore)
 
   # Check Rd manual files
   rd_files <- list.files(file.path(pkg$path, "man"), "\\.Rd$", full.names = TRUE)
-  rd_lines <- lapply(sort(rd_files), spell_check_rd, ignore = ignore)
+  rd_lines <- lapply(sort(rd_files), spell_check_rd, ignore = ignore, ...)
 
   # Check 'DESCRIPTION' fields
   pkg_fields <- c("title", "description")
   pkg_lines <- lapply(pkg_fields, function(x){
-    spell_check_file(textConnection(pkg[[x]]), ignore = ignore)
+    spell_check_file(textConnection(pkg[[x]]), ignore = ignore, ...)
   })
 
   # Combine
@@ -52,19 +53,19 @@ print.spellcheck <- function(x, ...){
   }
 }
 
-spell_check_text <- function(text, ignore){
-  bad_words <- hunspell::hunspell(text, ignore = ignore)
+spell_check_text <- function(text, ignore, ...){
+  bad_words <- hunspell::hunspell(text, ignore = ignore, ...)
   vapply(sort(unique(unlist(bad_words))), function(word) {
     line_numbers <- which(vapply(bad_words, `%in%`, x = word, logical(1)))
     paste(line_numbers, collapse = ",")
   }, character(1))
 }
 
-spell_check_file <- function(file, ignore){
-  spell_check_text(readLines(file), ignore = ignore)
+spell_check_file <- function(file, ignore, ...){
+  spell_check_text(readLines(file), ignore = ignore, ...)
 }
 
-spell_check_rd <- function(rdfile, ignore){
+spell_check_rd <- function(rdfile, ignore, ...){
   text <- tools::RdTextFilter(rdfile)
-  spell_check_text(text, ignore = ignore)
+  spell_check_text(text, ignore = ignore, ...)
 }

--- a/man/spell_check.Rd
+++ b/man/spell_check.Rd
@@ -4,7 +4,7 @@
 \alias{spell_check}
 \title{Spell checking}
 \usage{
-spell_check(pkg = ".", ignore = character())
+spell_check(pkg = ".", ignore = character(), ...)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -12,6 +12,8 @@ spell_check(pkg = ".", ignore = character())
 
 \item{ignore}{character vector with words to ignore. See
 \code{\link[hunspell:hunspell]{hunspell}} for more information}
+
+\item{...}{additional arguments passed to \code{\link[hunspell:hunspell]{hunspell}}}
 }
 \description{
 Runs a spell check on text fields in the package description file and


### PR DESCRIPTION
Pass arguments along to hunspell to allow, for example, dictionaries for languages other than American.