### PR TITLE
remind users that REMOTES still need IMPORT and friend entries

### DIFF
--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -52,6 +52,11 @@ A type of 'github' can be specified, but is not required
 Remotes: github::hadley/ggplot2
 ```
 
+Remember that the `Remotes:` field only specifies the *source* of a package, but it does not actually make it available to the R session.
+You still also have to call the package in `Imports:`, `Suggests:` `Depends:` or  `LinkingTo:`.
+In the above example, where the *package name* and the *repo name* are identical, you still need `Imports: ggplot2` in your `DESCRIPTION`.
+
+
 ### Other sources
 
 All of the currently supported install sources are available, see the 'See

--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -52,9 +52,8 @@ A type of 'github' can be specified, but is not required
 Remotes: github::hadley/ggplot2
 ```
 
-Remember that the `Remotes:` field only specifies the *source* of a package, but it does not actually make it available to the R session.
-You still also have to call the package in `Imports:`, `Suggests:` `Depends:` or  `LinkingTo:`.
-In the above example, where the *package name* and the *repo name* are identical, you still need `Imports: ggplot2` in your `DESCRIPTION`.
+Remember that `Remotes:` specifies the *source* of a development package, so the package still needs to be listed in `Imports:`, `Suggests:` `Depends:` or `LinkingTo:`.
+For example, the above `DESCRIPTION` would also require an `Imports: ggplot2` line for `ggplot2` to actually be imported.
 
 
 ### Other sources


### PR DESCRIPTION
The `REMOTES` field *feels* so similar to the `IMPORTS` and friends fields in the `DESCRIPTION` that I thought a package would have to be called in only one of the two.
@jimhester reminded me in https://github.com/hadley/devtools/issues/944#issuecomment-278013085 that ain't so.
Hope this it clearer for other newbies.