### PR TITLE
Match depends correctly

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -319,7 +319,7 @@ add_desc_package <- function(pkg = ".", field, name) {
     new <- name
     changed <- TRUE
   } else {
-    if (!grepl(name, old)) {
+    if (!grepl(paste0('\\W', name, '(,|$|\\s)'), old)) {
       new <- paste0(old, ",\n    ", name)
       changed <- TRUE
     } else {

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -319,7 +319,7 @@ add_desc_package <- function(pkg = ".", field, name) {
     new <- name
     changed <- TRUE
   } else {
-    if (!grepl(paste0('\\W', name, '(,|$|\\s)'), old)) {
+    if (!grepl(paste0('\\b', name, '\\b'), old)) {
       new <- paste0(old, ",\n    ", name)
       changed <- TRUE
     } else {


### PR DESCRIPTION
This change ensures that only exact matches in imports will get ignored. Currently adding e.g. `plyr` to a package that already imports `dplyr` will silently fail. This will happen for all packages that are substrings of packages already ignored.

The proposed change adds regex "fences" around the name of the package to import to circumvent this...