### PR TITLE
Refactor 'install_remote()'

### DIFF
--- a/R/install.r
+++ b/R/install.r
@@ -93,14 +93,8 @@ install <-
     return(invisible(FALSE))
   }
 
-  if (!is.null(out_dir)) {
-    out_file <- file.path(out_dir, paste0(pkg$package, ".out"))
-    if (skip_if_log_exists && file.exists(out_file)) {
-      message("Skipping ", pkg$package, ", installation failed before, see log in ", out_file)
-      return(invisible(FALSE))
-    }
-  } else {
-    out_file <- NULL
+  if (skip_since_log_exists(pkg$package, out_dir, skip_if_log_exists)) {
+    return(invisible(FALSE))
   }
 
   installing$packages <- c(installing$packages, pkg$package)

--- a/R/install.r
+++ b/R/install.r
@@ -149,7 +149,7 @@ install <-
 
   pkgbuild::rcmd_build_tools(
     "INSTALL",
-    c(shQuote(built_path), args),
+    c(shQuote(built_path), opts),
     echo = !quiet,
     show = !quiet,
     fail_on_status = TRUE,


### PR DESCRIPTION
### Changes
- Making `install_remote()` smaller to improve readability
  - Modularize the codes of checking conditions to skip installation as a function `check_if_skip_install_remote`
- Remove duplicated codes in `install()`
  - Previously, the lines 33 ~ 39 of `install-remote.R` and the lines 96 ~ 102 of `install.R` were duplicated.
  - This update will replace those duplication as a `skip_since_log_exists()`f
- Fix #1491 

