### PR TITLE
Check for suggested package (testthat) before use.

### DIFF
--- a/inst/templates/testthat.R
+++ b/inst/templates/testthat.R
@@ -1,4 +1,10 @@
-library(testthat)
-library({{{ name }}})
+if (requireNamespace("testthat", quietly = TRUE)) {
+  library(testthat)
+  library({{{ name }}})
 
-test_check("{{{ name }}}")
+  test_check("{{{ name }}}")
+} else {
+    warning("Tests not run. testthat package not present.", call. = FALSE)
+}
+
+


### PR DESCRIPTION
Inspired by recent Dirk Eddelbuettel post on suggests != depends I checked my packages to see whether I was checking for presence of suggested packages before using them. Spotted the absence of a check in the testthat setup generated by devtools.

http://dirk.eddelbuettel.com/blog/2017/03/22/#suggests_is_not_depends

I have no strong opinions on whether this is necessary / appropriate for tests or, if it is, whether I have suggested the best approach.