### PR TITLE
No shQuote for new pkgbuild/callr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ Suggests:
 Remotes:
   hadley/testthat,
   r-pkgs/pkgload,
+  r-pkgs/pkgbuild@HEAD,
   mangothecat/callr
 License: GPL (>= 2)
 VignetteBuilder: knitr

--- a/R/check.r
+++ b/R/check.r
@@ -162,7 +162,7 @@ check_built <- function(path = NULL, cran = TRUE,
 
   pkgbuild::rcmd_build_tools(
     "check",
-    c(shQuote(path), args),
+    c(path, args),
     wd = check_dir,
     env = env_vars,
     echo = !quiet,

--- a/R/install.r
+++ b/R/install.r
@@ -155,7 +155,7 @@ install <-
 
   pkgbuild::rcmd_build_tools(
     "INSTALL",
-    c(shQuote(built_path), args),
+    c(built_path, args),
     echo = !quiet,
     show = !quiet,
     fail_on_status = TRUE,

--- a/R/install.r
+++ b/R/install.r
@@ -155,7 +155,7 @@ install <-
 
   pkgbuild::rcmd_build_tools(
     "INSTALL",
-    c(built_path, args),
+    c(built_path, opts),
     echo = !quiet,
     show = !quiet,
     fail_on_status = TRUE,


### PR DESCRIPTION
New callr uses processx, so don't need to quote
paths any more. (It is actually a bug to quote
them.)

This also requires pinning pkgbuild to HEAD,
unfortunately. This should be temporary.