### PR TITLE
Escape special characters in GitHub ref

### DIFF
--- a/R/install-github.r
+++ b/R/install-github.r
@@ -174,7 +174,8 @@ github_resolve_ref <- function(x, params) UseMethod("github_resolve_ref")
 
 #' @export
 github_resolve_ref.default <- function(x, params) {
-  params$ref <- x
+  # ref can contain special characters like "#"
+  params$ref <- curl::curl_escape(x)
   params
 }
 

--- a/R/install-github.r
+++ b/R/install-github.r
@@ -192,7 +192,7 @@ github_resolve_ref.github_pull <- function(x, params) {
   response <- github_GET(path)
 
   params$username <- response$head$user$login
-  params$ref <- response$head$ref
+  params$ref <- curl::curl_escape(response$head$ref)
   params
 }
 
@@ -205,7 +205,7 @@ github_resolve_ref.github_release <- function(x, params) {
   if (length(response) == 0L)
     stop("No releases found for repo ", params$username, "/", params$repo, ".")
 
-  params$ref <- response[[1L]]$tag_name
+  params$ref <- curl::curl_escape(response[[1L]]$tag_name)
   params
 }
 


### PR DESCRIPTION
Currently, `install_github()` fails with branches that contain special characters. A reprex is here:

``` r
devtools::install_github("yutannihilation/devtools@escape-#")
#> Using GitHub PAT from envvar GITHUB_PAT
#> Downloading GitHub repo yutannihilation/devtools@escape-#
#> from URL https://api.github.com/repos/yutannihilation/devtools/zipball/escape-#
#> condition in stop(github_error(request)): 404: Not Found
#>  (404)
```

The URL should be `https://api.github.com/repos/yutannihilation/devtools/zipball/escape-%23`, in which the special character `#` is escaped to `%23`. This PR fixes the issue by escaping it with `curl::curl_escape()`.