### PR TITLE
Pass credentials to git2r::remote_ls in remote_sha.git_remote

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.12.0.9000
 
+* Bugfix for installing from git remote and not passing git2r credentials (@james-atkins, ##1498)
+
 * Bugfix for installation of dependencies of dependencies (@jimhester, #1409).
 
 * `RCMD()`, `clean_source()`, `eval_clean()` and `evalq_clean()` have been

--- a/R/install-git.r
+++ b/R/install-git.r
@@ -111,7 +111,7 @@ remote_sha.git_remote <- function(remote, ...) {
   }
 
   tryCatch({
-    res <- git2r::remote_ls(remote$url, ...)
+    res <- git2r::remote_ls(remote$url, credentials=remote$credentials, ...)
 
     branch <- remote$branch %||% "master"
 


### PR DESCRIPTION
Fixes #1498.