### PR TITLE
Throw error if commas missing in remotes

### DIFF
--- a/R/deps.R
+++ b/R/deps.R
@@ -199,7 +199,7 @@ parse_one_remote <- function(x) {
 split_remotes <- function(x) {
   pkgs <- trim_ws(unlist(strsplit(x, ",[[:space:]]*")))
   if (any(grepl("\n", pkgs, fixed = TRUE))) {
-    stop("Use commas to separate entries in remote specification '", x, "'", call. = FALSE)
+    stop("Missing commas separating remotes: '", x, "'", call. = FALSE)
   }
   pkgs
 }

--- a/R/deps.R
+++ b/R/deps.R
@@ -197,7 +197,11 @@ parse_one_remote <- function(x) {
 }
 
 split_remotes <- function(x) {
-  trim_ws(unlist(strsplit(x, ",[[:space:]]*")))
+  pkgs <- trim_ws(unlist(strsplit(x, ",[[:space:]]*")))
+  if (any(grepl("\n", pkgs, fixed = TRUE))) {
+    stop("Use commas to separate entries in remote specification '", x, "'", call. = FALSE)
+  }
+  pkgs
 }
 
 remote_deps <- function(pkg) {


### PR DESCRIPTION
If commas are missing between entries on separate lines under `Remotes:` in DESCRIPTION, the resulting error is:
```r
Error in curl::curl_fetch_disk(url, x$path, handle = handle) : 
  URL using bad/illegal format or missing URL
```
This does not provide much help to the user.

I think omitting these commas is a common mistake. For example: https://github.com/hadley/devtools/issues/1055

With the changes in this pull request, devtools throws an informative error in this case. The code checks for a newline in any of the remotes entries after splitting them on commas followed by optional space characters (which includes newlines).