### PR TITLE
Fix use_readme_rmd() so that a pre-commit hook is registered if pkg uses git

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -505,7 +505,8 @@ use_readme_rmd <- function(pkg = ".") {
                ignore = TRUE, open = TRUE, pkg = pkg)
   use_build_ignore("^README-.*\\.png$", escape = FALSE, pkg = pkg)
 
-  if (uses_git(pkg$path) && !file.exists(pkg$path, ".git", "hooks", "pre-commit")) {
+  if (uses_git(pkg$path) &&
+      !file.exists(file.path(pkg$path, ".git", "hooks", "pre-commit"))) {
     message("* Adding pre-commit hook")
     use_git_hook("pre-commit", render_template("readme-rmd-pre-commit.sh"),
       pkg = pkg)

--- a/tests/testthat/test-infrastructure.r
+++ b/tests/testthat/test-infrastructure.r
@@ -4,6 +4,7 @@ test_that("use_* functions consistently", {
   pkg <- "infrastructure"
   unlink(pkg, recursive = TRUE)
   withr::with_output_sink(tempfile(), create(pkg))
+  mock_use_github(pkg = pkg)
 
   use_test("test1", pkg = pkg)
   use_package_doc(pkg = pkg)
@@ -19,6 +20,7 @@ test_that("use_* functions consistently", {
   use_data_raw(pkg = pkg)
 
   use_readme_rmd(pkg = pkg)
+  expect_true(file.exists(file.path(pkg, ".git", "hooks", "pre-commit")))
   use_readme_md(pkg = pkg)
   use_news_md(pkg = pkg)
 


### PR DESCRIPTION
AFAICT, this small bug meant that the registration of the pre-commit hook was never triggered because the file path was not properly constructed.

- [x] Test added
- [ ] `NEWS.md` updated (will do if change is approved)
- [ ] Re-run roxygen2 (I did this but it introduces some doc changes unrelated to this PR, so I didn't commit these)