### PR TITLE
revdep_check: use quiet argument in revdep_check_from_cache()

### DIFF
--- a/R/revdep.R
+++ b/R/revdep.R
@@ -175,7 +175,7 @@ revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,
   )
   saveRDS(cache, revdep_cache_path(pkg))
 
-  revdep_check_from_cache(pkg, cache)
+  revdep_check_from_cache(pkg, cache, quiet = quiet_check)
 }
 
 #' @export
@@ -221,20 +221,20 @@ revdep_check_reset <- function(pkg = ".") {
   invisible(TRUE)
 }
 
-revdep_check_from_cache <- function(pkg, cache) {
+revdep_check_from_cache <- function(pkg, cache, quiet = TRUE) {
   # Install all dependencies for this package into revdep library --------------
   if (!file.exists(cache$libpath)) {
-    dir.create(cache$libpath, recursive = TRUE, showWarnings = FALSE)
+    dir.create(cache$libpath, recursive = TRUE, showWarnings = !quiet)
   }
   message(
     "Installing dependencies for ", pkg$package, " to ", cache$libpath
   )
 
   # For installing from GitHub, if git2r is not installed in the cache$libpath
-  requireNamespace("git2r", quietly = TRUE)
+  requireNamespace("git2r", quietly = quiet)
 
   withr::with_libpaths(cache$libpath, {
-    install_deps(pkg, reload = FALSE, quiet = TRUE, dependencies = TRUE)
+    install_deps(pkg, reload = FALSE, quiet = quiet, dependencies = TRUE)
   })
 
   # Always install this package into temporary library, to allow parallel ------
@@ -247,7 +247,7 @@ revdep_check_from_cache <- function(pkg, cache) {
     "Installing ", pkg$package, " ", pkg$version, " to ", temp_libpath
   )
   withr::with_libpaths(c(temp_libpath, cache$libpath), {
-    install(pkg, reload = FALSE, quiet = TRUE, dependencies = FALSE)
+    install(pkg, reload = FALSE, quiet = quiet, dependencies = FALSE)
   })
 
   cache$env_vars <- c(


### PR DESCRIPTION
This updates revdep_check() to pass its quiet_check parameter into revdep_check_from_cache(), allowing revdep_check_from_cache() to display extra output if desired.

This is helpful for example in Travis-CI, where the current version can fail for not displaying any output for 10 minutes. It also is helpful to debug why a Travis build may fail during revdep_check().

Example output from current devtools where Travis fails due to lack of output during revdep_check(): https://travis-ci.org/ck37/SuperLearner/jobs/245155188#L2275

<img width="723" alt="screen shot 2017-06-21 at 8 23 07 am" src="https://user-images.githubusercontent.com/50770/27392282-2c461ae2-565b-11e7-835c-96cbe9534a05.png">

Example output from a patched devtools: https://travis-ci.org/ck37/SuperLearner/jobs/245161356#L3082

<img width="633" alt="screen shot 2017-06-21 at 8 26 58 am" src="https://user-images.githubusercontent.com/50770/27392398-71210bf4-565b-11e7-9da9-149ed44472c4.png">
