### PR TITLE
Remove hard-coded NA for dependences

### DIFF
--- a/R/install-remote.R
+++ b/R/install-remote.R
@@ -39,7 +39,7 @@ install_remote <- function(remote, ..., force = FALSE, quiet = FALSE,
   }
 
   if (is_windows && inherits(remote, "cran_remote")) {
-    install_packages(package_name, repos = remote$repos, type = remote$pkg_type, dependencies = NA, ..., quiet = quiet,
+    install_packages(package_name, repos = remote$repos, type = remote$pkg_type, ..., quiet = quiet,
                      out_dir = out_dir, skip_if_log_exists = skip_if_log_exists)
     return(invisible(TRUE))
   }


### PR DESCRIPTION
Hard-coding dependencies = NA into the install_packages function within install_remote appears to cause the error:
"Installation failed: missing value where TRUE/FALSE needed"
when using install_git