### PR TITLE
Fix error if no misspellings found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # devtools 1.13.2
 Workaround a regression in Rcpp::compileAttributes.
 Add trimws implementation for R 3.1 support.
+* Fix arcane error message in `spell_check` when package has no spelling errors (@hughparsonage)
 
 # devtools 1.13.1
 

--- a/R/spell-check.R
+++ b/R/spell-check.R
@@ -50,13 +50,15 @@ spell_check <- function(pkg = ".", ignore = character(), dict = "en_US"){
 #' @export
 print.spellcheck <- function(x, ...){
   words <- names(x)
-  fmt <- paste0("%-", max(nchar(words)) + 3, "s")
-  pretty_names <- sprintf(fmt, words)
-  cat(sprintf(fmt, "  WORD"), "  FOUND IN\n", sep = "")
-  for(i in seq_along(x)){
-    cat(pretty_names[i])
-    cat(paste(x[[i]], collapse = ", "))
-    cat("\n")
+  if (length(words) > 0) {
+    fmt <- paste0("%-", max(nchar(words)) + 3, "s")
+    pretty_names <- sprintf(fmt, words)
+    cat(sprintf(fmt, "  WORD"), "  FOUND IN\n", sep = "")
+    for(i in seq_along(x)){
+      cat(pretty_names[i])
+      cat(paste(x[[i]], collapse = ", "))
+      cat("\n")
+    }
   }
 }
 


### PR DESCRIPTION
If `spell_check` is run on a package where no words have been misspelled, the function returns an arcane error message

> Error in sprintf(fmt, "  WORD") : 
>   invalid format '%--Inf'; use format %s for character objects
> In addition: Warning message:
> In max(nchar(words)) : no non-missing arguments to max; returning -Inf

I propose that when no bad words are encountered, the function should return `NULL`. In particular, it should not error.

- [x] Style: I have kept to the style guide. (The `for(` parenthesis spacing has been left as it was.)
- [x] Added bullet point to NEWS.md
- [ ] Write a test. I was unable to write a short test. I note this function is not the subject of a unit test https://codecov.io/gh/hadley/devtools/src/master/R/spell-check.R I believe the only way to test this function or this extension would be to download a package free of spelling errors. Doing this seemed excessive for this pull request.
- [x] New parameters or new function: Not applicable.