### PR TITLE
remove 'check = 0' argument passed to git2r::discover_repository().

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -1,5 +1,5 @@
 uses_git <- function(path = ".") {
-  !is.null(git2r::discover_repository(path, ceiling = 0))
+  !is.null(git2r::discover_repository(path))
 }
 
 # sha of most recent commit


### PR DESCRIPTION
This PR fixes the error in [issue #1568](https://github.com/hadley/devtools/issues/1568) by removing the `check = 0` argument passed to `git2r::discover_respository` located [here](https://github.com/hadley/devtools/blob/d5d9846ed2b0d9ae521b40a53678dd1e20fa84cc/R/git.R#L2).