### PR TITLE
Clarified default argument for `version` in `build_win`

### DIFF
--- a/R/build-win.r
+++ b/R/build-win.r
@@ -13,17 +13,18 @@
 #' @param quiet If \code{TRUE}, suppresses outut.
 #' @param version directory to upload to on the win-builder, controlling
 #'   which version of R is used to build the package. Possible options are
-#'   listed on \url{http://win-builder.r-project.org/}. Defaults to R-devel.
+#'   \code{'R-devel'} and \code{'R-release'} (see 
+#'   \url{http://win-builder.r-project.org/}). Multiple options are allowed.
 #' @export
 #' @family build functions
-build_win <- function(pkg = ".", version = c("R-release", "R-devel"),
+build_win <- function(pkg = ".", version = "R-devel",
                       args = NULL, quiet = FALSE) {
   pkg <- as.package(pkg)
 
-  if (missing(version)) {
-    version <- "R-devel"
-  } else {
-    version <- match.arg(version, several.ok = TRUE)
+  available_versions <- c("R-devel", "R-release")
+  if (!all(version %in% available_versions)) {
+    stop("'version' should be one or more of ", 
+      paste0("'", available_versions, "'", collapse=", "), ".")
   }
 
   if (!quiet) {


### PR DESCRIPTION
The current interface to `build_win` is:
```
build_win <- function(pkg = ".", version = c("R-release", "R-devel"),
   args = NULL, quiet = FALSE) {
```
which suggests that the default argument for version is either `"R-release"` or `c("R-release", "R-devel")`, but not `"R-devel"` which *is* the default argument. 

Furthermore the documentation of the `version` argument is incorrect:

```
#' @param version directory to upload to on the win-builder, controlling
#'   which version of R is used to build the package. Possible options are
#'   listed on \url{http://win-builder.r-project.org/}. Defaults to R-devel.
```

The url lists more options: R-oldrel, which is not accepted by `build_win`. 

A minimal correction would be to change the default argument to `c("R-devel", "R-release")` and correct the documentation. The disadvantage of that is that, since `version` accepts multiple arguments, this could be interpreted as that the package will be built for both releases. Another disadvantage (because of `match.arg(..., several.ok = TRUE)`) is that `build_win(version = c("R-devel", "some typo")` doesn't do what is expected: generate an error or at least a warning. 

The solution I propose avoids both issues of the more simple solution. The only disadvantage I can think of, is that the partial matching of `match.arg` doesn't work anymore. Existing code that uses that, would break. 



