### PR TITLE
Fix the test failures / errors and add a warning for pkg arguments that are not `.`.

### DIFF
--- a/R/infrastructure-git.R
+++ b/R/infrastructure-git.R
@@ -2,6 +2,7 @@
 #' @export
 use_git <- function(message = "Initial commit", pkg = ".") {
   .Deprecated("usethis::use_git()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_git(message = message)
 }
 
@@ -41,6 +42,7 @@ use_github <- function(auth_token = github_pat(), private = FALSE, pkg = ".",
                        host = "https://api.github.com",
                        protocol = c("ssh", "https"), credentials = NULL, ...) {
   .Deprecated("usethis::use_github()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_github(auth_token = auth_token, private = private, host = host,
                       protocol = protocol, credentials = credentials, ...)
 }
@@ -49,6 +51,7 @@ use_github <- function(auth_token = github_pat(), private = FALSE, pkg = ".",
 #' @export
 use_git_hook <- function(hook, script, pkg = ".") {
   .Deprecated("usethis::use_git_hook()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_git_hook(hook = hook, script = script)
 }
 
@@ -72,5 +75,6 @@ use_git_ignore <- function(ignores, directory = ".", pkg = ".", quiet = FALSE) {
 use_github_links <- function(pkg = ".", auth_token = github_pat(),
                              host = "https://api.github.com") {
   .Deprecated("usethis::use_github_links()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_github_links(auth_token = auth_token, host = host)
 }

--- a/R/infrastructure-git.R
+++ b/R/infrastructure-git.R
@@ -2,7 +2,7 @@
 #' @export
 use_git <- function(message = "Initial commit", pkg = ".") {
   .Deprecated("usethis::use_git()", package = "devtools")
-  usethis::use_git(message = message, base_path = pkg)
+  usethis::use_git(message = message)
 }
 
 # This is still used internally in the devtools tests
@@ -42,14 +42,14 @@ use_github <- function(auth_token = github_pat(), private = FALSE, pkg = ".",
                        protocol = c("ssh", "https"), credentials = NULL, ...) {
   .Deprecated("usethis::use_github()", package = "devtools")
   usethis::use_github(auth_token = auth_token, private = private, host = host,
-                      protocol = protocol, credentials = credentials, base_path = pkg, ...)
+                      protocol = protocol, credentials = credentials, ...)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_git_hook <- function(hook, script, pkg = ".") {
   .Deprecated("usethis::use_git_hook()", package = "devtools")
-  usethis::use_git_hook(hook = hook, script = script, base_path = pkg)
+  usethis::use_git_hook(hook = hook, script = script)
 }
 
 # This is still used internally in the devtools tests
@@ -72,5 +72,5 @@ use_git_ignore <- function(ignores, directory = ".", pkg = ".", quiet = FALSE) {
 use_github_links <- function(pkg = ".", auth_token = github_pat(),
                              host = "https://api.github.com") {
   .Deprecated("usethis::use_github_links()", package = "devtools")
-  usethis::use_github_links(auth_token = auth_token, host = host, base_path = pkg)
+  usethis::use_github_links(auth_token = auth_token, host = host)
 }

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -5,6 +5,7 @@
 #' @export
 use_testthat <- function(pkg = ".") {
   .Deprecated("usethis::use_testthat()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_testthat()
 }
 
@@ -12,6 +13,7 @@ use_testthat <- function(pkg = ".") {
 #' @export
 use_test <- function(name, pkg = ".") {
   .Deprecated("usethis::use_test()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_test(name = name)
 }
 
@@ -19,6 +21,7 @@ use_test <- function(name, pkg = ".") {
 #' @export
 use_rstudio <- function(pkg = ".") {
   .Deprecated("usethis::use_rstudio()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_rstudio()
 }
 
@@ -26,6 +29,7 @@ use_rstudio <- function(pkg = ".") {
 #' @export
 use_vignette <- function(name, pkg = ".") {
   .Deprecated("usethis::use_vignette()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_vignette(name = name)
 }
 
@@ -33,6 +37,7 @@ use_vignette <- function(name, pkg = ".") {
 #' @export
 use_rcpp <- function(pkg = ".") {
   .Deprecated("usethis::use_rcpp()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_rcpp()
 }
 
@@ -40,6 +45,7 @@ use_rcpp <- function(pkg = ".") {
 #' @export
 use_travis <- function(pkg = ".", browse = interactive()) {
   .Deprecated("usethis::use_travis()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_travis(browse = browse)
 }
 
@@ -47,6 +53,7 @@ use_travis <- function(pkg = ".", browse = interactive()) {
 #' @export
 use_coverage <- function(pkg = ".", type = c("codecov", "coveralls")) {
   .Deprecated("usethis::use_coverage()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_coverage(type = type)
 }
 
@@ -54,6 +61,7 @@ use_coverage <- function(pkg = ".", type = c("codecov", "coveralls")) {
 #' @export
 use_appveyor <- function(pkg = ".") {
   .Deprecated("usethis::use_appveyor()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_appveyor()
 }
 
@@ -61,6 +69,7 @@ use_appveyor <- function(pkg = ".") {
 #' @export
 use_package_doc <- function(pkg = ".") {
   .Deprecated("usethis::use_package_doc()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_package_doc()
 }
 
@@ -68,6 +77,7 @@ use_package_doc <- function(pkg = ".") {
 #' @export
 use_package <- function(package, type = "Imports", pkg = ".") {
   .Deprecated("usethis::use_package()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_package(package = package, type = type)
 }
 
@@ -88,6 +98,7 @@ use_data <- usethis::use_data
 #' @export
 use_data_raw <- function(pkg = ".") {
   .Deprecated("usethis::use_data_raw()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_data_raw()
 }
 
@@ -95,6 +106,7 @@ use_data_raw <- function(pkg = ".") {
 #' @export
 use_build_ignore <- function(files, escape = TRUE, pkg = ".") {
   .Deprecated("usethis::use_build_ignore()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_build_ignore(files, escape = TRUE)
 }
 
@@ -102,6 +114,7 @@ use_build_ignore <- function(files, escape = TRUE, pkg = ".") {
 #' @export
 use_readme_rmd <- function(pkg = ".") {
   .Deprecated("usethis::use_readme_rmd()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_readme_rmd()
 }
 
@@ -109,6 +122,7 @@ use_readme_rmd <- function(pkg = ".") {
 #' @export
 use_readme_md <- function(pkg = ".") {
   .Deprecated("usethis::use_readme_md()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_readme_md()
 }
 
@@ -116,6 +130,7 @@ use_readme_md <- function(pkg = ".") {
 #' @export
 use_news_md <- function(pkg = ".") {
   .Deprecated("usethis::use_news_md()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_news_md()
 }
 
@@ -123,6 +138,7 @@ use_news_md <- function(pkg = ".") {
 #' @export
 use_revdep <- function(pkg = ".") {
   .Deprecated("usethis::use_revdep()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_revdep()
 }
 
@@ -130,6 +146,7 @@ use_revdep <- function(pkg = ".") {
 #' @export
 use_cran_comments <- function(pkg = ".") {
   .Deprecated("usethis::use_cran_comments()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_cran_comments()
 }
 
@@ -137,6 +154,7 @@ use_cran_comments <- function(pkg = ".") {
 #' @export
 use_code_of_conduct <- function(pkg = ".") {
   .Deprecated("usethis::use_code_of_conduct()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_code_of_conduct()
 }
 
@@ -144,6 +162,7 @@ use_code_of_conduct <- function(pkg = ".") {
 #' @export
 use_cran_badge <- function(pkg = ".") {
   .Deprecated("usethis::use_cran_badge()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_cran_badge()
 }
 
@@ -152,6 +171,7 @@ use_cran_badge <- function(pkg = ".") {
 use_mit_license <- function(pkg = ".",
                            copyright_holder = getOption("devtools.name", "<Author>")) {
   .Deprecated("usethis::use_mit_license()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_mit_license(copyright_holder = copyright_holder)
 }
 
@@ -159,6 +179,7 @@ use_mit_license <- function(pkg = ".",
 #' @export
 use_gpl3_license <- function(pkg = ".") {
   .Deprecated("usethis::use_gpl3_license()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_gpl3_license()
 }
 
@@ -166,6 +187,7 @@ use_gpl3_license <- function(pkg = ".") {
 #' @export
 use_dev_version <- function(pkg = ".") {
   .Deprecated("usethis::use_dev_version()", package = "devtools")
+  warn_unless_current_dir(pkg)
   usethis::use_dev_version()
 }
 

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -5,70 +5,70 @@
 #' @export
 use_testthat <- function(pkg = ".") {
   .Deprecated("usethis::use_testthat()", package = "devtools")
-  usethis::use_testthat(base_path = pkg)
+  usethis::use_testthat()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_test <- function(name, pkg = ".") {
   .Deprecated("usethis::use_test()", package = "devtools")
-  usethis::use_test(name = name, base_path = pkg)
+  usethis::use_test(name = name)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_rstudio <- function(pkg = ".") {
   .Deprecated("usethis::use_rstudio()", package = "devtools")
-  usethis::use_rstudio(base_path = pkg)
+  usethis::use_rstudio()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_vignette <- function(name, pkg = ".") {
   .Deprecated("usethis::use_vignette()", package = "devtools")
-  usethis::use_vignette(name = name, base_path = pkg)
+  usethis::use_vignette(name = name)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_rcpp <- function(pkg = ".") {
   .Deprecated("usethis::use_rcpp()", package = "devtools")
-  usethis::use_rcpp(base_path = pkg)
+  usethis::use_rcpp()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_travis <- function(pkg = ".", browse = interactive()) {
   .Deprecated("usethis::use_travis()", package = "devtools")
-  usethis::use_travis(browse = browse, base_path = pkg)
+  usethis::use_travis(browse = browse)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_coverage <- function(pkg = ".", type = c("codecov", "coveralls")) {
   .Deprecated("usethis::use_coverage()", package = "devtools")
-  usethis::use_coverage(type = type, base_path = pkg)
+  usethis::use_coverage(type = type)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_appveyor <- function(pkg = ".") {
   .Deprecated("usethis::use_appveyor()", package = "devtools")
-  usethis::use_appveyor(base_path = pkg)
+  usethis::use_appveyor()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_package_doc <- function(pkg = ".") {
   .Deprecated("usethis::use_package_doc()", package = "devtools")
-  usethis::use_package_doc(base_path = pkg)
+  usethis::use_package_doc()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_package <- function(package, type = "Imports", pkg = ".") {
   .Deprecated("usethis::use_package()", package = "devtools")
-  usethis::use_package(package = package, type = type, base_path = pkg)
+  usethis::use_package(package = package, type = type)
 }
 
 #' @rdname devtools-deprecated
@@ -81,70 +81,70 @@ use_data <- usethis::use_data
                      #compress = "bzip2") {
   #.Deprecated("usethis::use_data()", package = "devtools")
   #usethis::use_data(..., internal = internal, overwrite = overwrite,
-                    #compress = compress, base_path = pkg)
+                    #compress = compress)
 #}
 
 #' @rdname devtools-deprecated
 #' @export
 use_data_raw <- function(pkg = ".") {
   .Deprecated("usethis::use_data_raw()", package = "devtools")
-  usethis::use_data_raw(base_path = pkg)
+  usethis::use_data_raw()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_build_ignore <- function(files, escape = TRUE, pkg = ".") {
   .Deprecated("usethis::use_build_ignore()", package = "devtools")
-  usethis::use_build_ignore(files, escape = TRUE, base_path = pkg)
+  usethis::use_build_ignore(files, escape = TRUE)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_readme_rmd <- function(pkg = ".") {
   .Deprecated("usethis::use_readme_rmd()", package = "devtools")
-  usethis::use_readme_rmd(base_path = pkg)
+  usethis::use_readme_rmd()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_readme_md <- function(pkg = ".") {
   .Deprecated("usethis::use_readme_md()", package = "devtools")
-  usethis::use_readme_md(base_path = pkg)
+  usethis::use_readme_md()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_news_md <- function(pkg = ".") {
   .Deprecated("usethis::use_news_md()", package = "devtools")
-  usethis::use_news_md(base_path = pkg)
+  usethis::use_news_md()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_revdep <- function(pkg = ".") {
   .Deprecated("usethis::use_revdep()", package = "devtools")
-  usethis::use_revdep(base_path = pkg)
+  usethis::use_revdep()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_cran_comments <- function(pkg = ".") {
   .Deprecated("usethis::use_cran_comments()", package = "devtools")
-  usethis::use_cran_comments(base_path = pkg)
+  usethis::use_cran_comments()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_code_of_conduct <- function(pkg = ".") {
   .Deprecated("usethis::use_code_of_conduct()", package = "devtools")
-  usethis::use_code_of_conduct(base_path = pkg)
+  usethis::use_code_of_conduct()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_cran_badge <- function(pkg = ".") {
   .Deprecated("usethis::use_cran_badge()", package = "devtools")
-  usethis::use_cran_badge(base_path = pkg)
+  usethis::use_cran_badge()
 }
 
 #' @rdname devtools-deprecated
@@ -152,21 +152,21 @@ use_cran_badge <- function(pkg = ".") {
 use_mit_license <- function(pkg = ".",
                            copyright_holder = getOption("devtools.name", "<Author>")) {
   .Deprecated("usethis::use_mit_license()", package = "devtools")
-  usethis::use_mit_license(copyright_holder = copyright_holder, base_path = pkg)
+  usethis::use_mit_license(copyright_holder = copyright_holder)
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_gpl3_license <- function(pkg = ".") {
   .Deprecated("usethis::use_gpl3_license()", package = "devtools")
-  usethis::use_gpl3_license(base_path = pkg)
+  usethis::use_gpl3_license()
 }
 
 #' @rdname devtools-deprecated
 #' @export
 use_dev_version <- function(pkg = ".") {
   .Deprecated("usethis::use_dev_version()", package = "devtools")
-  usethis::use_dev_version(base_path = pkg)
+  usethis::use_dev_version()
 }
 
 # Needed for tests

--- a/R/utils.r
+++ b/R/utils.r
@@ -184,3 +184,10 @@ trim_ws <- function (x, which = c("both", "left", "right")) {
         return(mysub("[ \t\r\n]+$", x))
     mysub("[ \t\r\n]+$", mysub("^[ \t\r\n]+", x))
 }
+
+# throws a warning if the argument is not the current directory.
+warn_unless_current_dir <- function(pkg) {
+  if (pkg != ".") {
+    warning("`pkg` is not `.`, which is now unsupported.\n  Please use `usethis::proj_set()` to set the project directory.", immediate. = TRUE)
+  }
+}

--- a/tests/testthat/helper-github.R
+++ b/tests/testthat/helper-github.R
@@ -3,7 +3,9 @@ create_in_temp <- function(pkg) {
   temp_path <- tempfile(pattern="devtools-test-")
   dir.create(temp_path)
   test_pkg <- file.path(temp_path, pkg)
-  capture.output(suppressMessages(create(test_pkg, description = list())))
+  capture.output(suppressMessages(usethis::create_package(test_pkg, fields = list())))
+  old_proj <- usethis::proj_set(test_pkg)
+  withr::defer(usethis::proj_set(old_proj), parent.frame())
   test_pkg
 }
 
@@ -14,7 +16,8 @@ mock_use_github <- function(pkg) {
   use_git_with_config(message = "initial", pkg = pkg, add_user_config = TRUE, quiet = TRUE)
   r <- git2r::repository(pkg)
   git2r::remote_add(r, "origin", "https://github.com/hadley/devtools.git")
-  use_github_links(pkg)
+  withr::with_output_sink("ignore", usethis::use_github_links())
+  unlink("ignore")
   git2r::add(r, "DESCRIPTION")
   git2r::commit(r, "Add GitHub links to DESCRIPTION")
   invisible(NULL)

--- a/tests/testthat/test-github-connections.R
+++ b/tests/testthat/test-github-connections.R
@@ -32,7 +32,7 @@ test_that("GitHub non-usage is handled", {
 
   expect_identical(github_dummy, github_info(test_pkg))
 
-  expect_error(use_github_links(test_pkg), "Cannot detect .* GitHub")
+  expect_error(usethis::use_github_links(), "Cannot detect .* GitHub")
 
   erase(test_pkg)
 
@@ -58,7 +58,7 @@ test_that("github info and links can be queried and manipulated", {
   desc <- read_dcf(desc_path)
 
   ## default GitHub links created by use_github_links() via use_github()
-  expect_identical(desc[["Url"]],
+  expect_identical(desc[["URL"]],
                    file.path("https://github.com",
                              gh_info$username, gh_info$repo))
   expect_identical(desc[["BugReports"]],


### PR DESCRIPTION
Would like suggestions on the warning message.

https://github.com/hadley/devtools/compare/master...jimhester:github-connection-tests?expand=1#diff-475284c83f91b5f64ec0e4afdbd4c955R191