### PR TITLE
Add check_dir argument for backwards compatibility

### DIFF
--- a/R/check.r
+++ b/R/check.r
@@ -44,6 +44,9 @@
 #'   rerun \code{\link{document}} prior to checking. Use \code{TRUE}
 #'   and \code{FALSE} to override this default.
 #' @param build_args Additional arguments passed to \code{R CMD build}
+#' @param check_dir This argument is ignored, and exists only for backwards
+#'   compatibility. \code{args = "--output=/foo/bar"} can be used to change the
+#'   check directory.
 #' @param ... Additional arguments passed on to \code{\link[pkgbuild]{build}()}.
 #' @seealso \code{\link{release}} if you want to send the checked package to
 #'   CRAN.
@@ -59,7 +62,8 @@ check <- function(pkg = ".",
                   run_dont_test = FALSE,
                   args = NULL,
                   env_vars = NULL,
-                  quiet = FALSE) {
+                  quiet = FALSE,
+                  check_dir) {
   pkg <- as.package(pkg)
 
   if (rstudioapi::hasFun("documentSaveAll")) {

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -7,7 +7,8 @@
 \usage{
 check(pkg = ".", document = NA, build_args = NULL, ..., manual = FALSE,
   cran = TRUE, check_version = FALSE, force_suggests = FALSE,
-  run_dont_test = FALSE, args = NULL, env_vars = NULL, quiet = FALSE)
+  run_dont_test = FALSE, args = NULL, env_vars = NULL, quiet = FALSE,
+  check_dir)
 
 check_built(path = NULL, cran = TRUE, check_version = FALSE,
   force_suggests = FALSE, run_dont_test = FALSE, manual = FALSE,
@@ -48,6 +49,10 @@ submission.}
 \item{env_vars}{Environment variables set during \code{R CMD check}}
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
+
+\item{check_dir}{This argument is ignored, and exists only for backwards
+compatibility. \code{args = "--output=/foo/bar"} can be used to change the
+check directory.}
 
 \item{path}{Path to built package.}
 }


### PR DESCRIPTION
This adds back the check_dir argument, although it is now ignored. The RStudio IDE calls `devtools::check()` with this argument, which caused #1592.

The `check_dir` argument was originally added for #337, however rcmdcheck does support the `--output` argument to `R CMD check`, so you can specify the check directory by passing `args = "--output=/foo/bar"` (as I mentioned in the help for `check_dir`.

Alternatively we could modify `rcmdcheck()` to take a `check_dir` argument or add the `args = "--output"` if `check_dir` is not `NULL`. Not sure what the best approach is.