### PR TITLE
Reinstate package coercion in check_win family

### DIFF
--- a/R/check-win.r
+++ b/R/check-win.r
@@ -37,6 +37,7 @@ check_win_oldrelease <- function(pkg = ".", args = NULL, quiet = FALSE) {
 check_win <- function(pkg = ".", version = c("R-devel", "R-release", "R-oldrelease"),
                       args = NULL, quiet = FALSE) {
 
+  pkg <- as.package(pkg)
   version <- match.arg(version, several.ok = TRUE)
 
   if (!quiet) {


### PR DESCRIPTION
Otherwise we get:

```
check_win_release()
#> Error in pkg$package : $ operator is invalid for atomic vectors 
```