### PR TITLE
[my_unzip] add exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,8 @@
 * In order to not run test helpers in `document()`, the `helpers` argument of
   `load_all()` is set to `FALSE` (@nbenn, #1669)
 
+* The `my_unzip()` function is now able to use the `utils::unzip` fallback when R is compiled from source with no *unzip* package present (@theGreatWhiteShark, #1678)
+
 # devtools 1.13.2
 Workaround a regression in Rcpp::compileAttributes.
 Add trimws implementation for R 3.1 support.

--- a/R/decompress.r
+++ b/R/decompress.r
@@ -88,7 +88,7 @@ getrootdir <- function(file_list) {
 }
 
 my_unzip <- function(src, target, unzip = getOption("unzip")) {
-  if (unzip == "internal") {
+  if (unzip == "internal" | unzip == "") {
     return(utils::unzip(src, exdir = target))
   }
 

--- a/R/decompress.r
+++ b/R/decompress.r
@@ -88,7 +88,7 @@ getrootdir <- function(file_list) {
 }
 
 my_unzip <- function(src, target, unzip = getOption("unzip")) {
-  if (unzip == "internal" | unzip == "") {
+  if (unzip == "internal" || unzip == "") {
     return(utils::unzip(src, exdir = target))
   }
 


### PR DESCRIPTION
Whenever R is compiled with no 'unzip' package installed in the underlying operation system, the getOption( 'unzip' ) variable is set to an empty string. (At least for R-3.4.0 on a vanilla Ubuntu16.04

Since the empty string doesn't trigger the if clause and its usage of the R interal utils::unzip function, I added another exception.