### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Building and installing:
 Check and release:
 
 * `check()` updates the documentation, then builds and checks the package. 
-  `build_win()` builds a package using 
+  `check_win()` builds a package using 
   [win-builder](http://win-builder.r-project.org/), allowing you to easily check 
   your package on windows.
 


### PR DESCRIPTION
the `build_win` function was replaced by the `check_win` function.

This change is now added to the README.

(See issue #1696 )